### PR TITLE
Smm Store 2

### DIFF
--- a/Bootloader/coreboot/Include/Coreboot.h
+++ b/Bootloader/coreboot/Include/Coreboot.h
@@ -1,0 +1,263 @@
+/** @file
+  Coreboot PEI module include file.
+
+  Copyright (c) 2014 - 2015, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/*
+ * This file is part of the libpayload project.
+ *
+ * Copyright (C) 2008 Advanced Micro Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _COREBOOT_PEI_H_INCLUDED_
+#define _COREBOOT_PEI_H_INCLUDED_
+
+#if defined (_MSC_VER)
+  #pragma warning( disable : 4200 )
+#endif
+
+#define DYN_CBMEM_ALIGN_SIZE  (4096)
+
+#define IMD_ENTRY_MAGIC    (~0xC0389481)
+#define CBMEM_ENTRY_MAGIC  (~0xC0389479)
+
+struct cbmem_entry {
+  UINT32    magic;
+  UINT32    start;
+  UINT32    size;
+  UINT32    id;
+};
+
+struct cbmem_root {
+  UINT32                max_entries;
+  UINT32                num_entries;
+  UINT32                locked;
+  UINT32                size;
+  struct cbmem_entry    entries[0];
+};
+
+struct imd_entry {
+  UINT32    magic;
+  UINT32    start_offset;
+  UINT32    size;
+  UINT32    id;
+};
+
+struct imd_root {
+  UINT32              max_entries;
+  UINT32              num_entries;
+  UINT32              flags;
+  UINT32              entry_align;
+  UINT32              max_offset;
+  struct imd_entry    entries[0];
+};
+
+struct cbuint64 {
+  UINT32    lo;
+  UINT32    hi;
+};
+
+#define CB_HEADER_SIGNATURE  0x4F49424C
+
+struct cb_header {
+  UINT32    signature;
+  UINT32    header_bytes;
+  UINT32    header_checksum;
+  UINT32    table_bytes;
+  UINT32    table_checksum;
+  UINT32    table_entries;
+};
+
+struct cb_record {
+  UINT32    tag;
+  UINT32    size;
+};
+
+#define CB_TAG_UNUSED  0x0000
+#define CB_TAG_MEMORY  0x0001
+
+struct cb_memory_range {
+  struct cbuint64    start;
+  struct cbuint64    size;
+  UINT32             type;
+};
+
+#define CB_MEM_RAM          1
+#define CB_MEM_RESERVED     2
+#define CB_MEM_ACPI         3
+#define CB_MEM_NVS          4
+#define CB_MEM_UNUSABLE     5
+#define CB_MEM_VENDOR_RSVD  6
+#define CB_MEM_TABLE        16
+
+struct cb_memory {
+  UINT32                    tag;
+  UINT32                    size;
+  struct cb_memory_range    map[0];
+};
+
+#define CB_TAG_MAINBOARD  0x0003
+
+struct cb_mainboard {
+  UINT32    tag;
+  UINT32    size;
+  UINT8     vendor_idx;
+  UINT8     part_number_idx;
+  UINT8     strings[0];
+};
+
+#define CB_TAG_VERSION         0x0004
+#define CB_TAG_EXTRA_VERSION   0x0005
+#define CB_TAG_BUILD           0x0006
+#define CB_TAG_COMPILE_TIME    0x0007
+#define CB_TAG_COMPILE_BY      0x0008
+#define CB_TAG_COMPILE_HOST    0x0009
+#define CB_TAG_COMPILE_DOMAIN  0x000a
+#define CB_TAG_COMPILER        0x000b
+#define CB_TAG_LINKER          0x000c
+#define CB_TAG_ASSEMBLER       0x000d
+
+struct cb_string {
+  UINT32    tag;
+  UINT32    size;
+  UINT8     string[0];
+};
+
+#define CB_TAG_SERIAL  0x000f
+
+struct cb_serial {
+  UINT32    tag;
+  UINT32    size;
+  #define CB_SERIAL_TYPE_IO_MAPPED      1
+  #define CB_SERIAL_TYPE_MEMORY_MAPPED  2
+  UINT32    type;
+  UINT32    baseaddr;
+  UINT32    baud;
+  UINT32    regwidth;
+
+  // Crystal or input frequency to the chip containing the UART.
+  // Provide the board specific details to allow the payload to
+  // initialize the chip containing the UART and make independent
+  // decisions as to which dividers to select and their values
+  // to eventually arrive at the desired console baud-rate.
+  UINT32    input_hertz;
+
+  // UART PCI address: bus, device, function
+  // 1 << 31 - Valid bit, PCI UART in use
+  // Bus << 20
+  // Device << 15
+  // Function << 12
+  UINT32    uart_pci_addr;
+};
+
+#define CB_TAG_CONSOLE  0x00010
+
+struct cb_console {
+  UINT32    tag;
+  UINT32    size;
+  UINT16    type;
+};
+
+#define CB_TAG_CONSOLE_SERIAL8250  0
+#define CB_TAG_CONSOLE_VGA         1 // OBSOLETE
+#define CB_TAG_CONSOLE_BTEXT       2 // OBSOLETE
+#define CB_TAG_CONSOLE_LOGBUF      3
+#define CB_TAG_CONSOLE_SROM        4// OBSOLETE
+#define CB_TAG_CONSOLE_EHCI        5
+
+#define CB_TAG_FORWARD  0x00011
+
+struct cb_forward {
+  UINT32    tag;
+  UINT32    size;
+  UINT64    forward;
+};
+
+#define CB_TAG_FRAMEBUFFER  0x0012
+struct cb_framebuffer {
+  UINT32    tag;
+  UINT32    size;
+
+  UINT64    physical_address;
+  UINT32    x_resolution;
+  UINT32    y_resolution;
+  UINT32    bytes_per_line;
+  UINT8     bits_per_pixel;
+  UINT8     red_mask_pos;
+  UINT8     red_mask_size;
+  UINT8     green_mask_pos;
+  UINT8     green_mask_size;
+  UINT8     blue_mask_pos;
+  UINT8     blue_mask_size;
+  UINT8     reserved_mask_pos;
+  UINT8     reserved_mask_size;
+};
+
+#define CB_TAG_VDAT  0x0015
+struct cb_vdat {
+  UINT32    tag;
+  UINT32    size; /* size of the entire entry */
+  UINT64    vdat_addr;
+  UINT32    vdat_size;
+};
+
+#define CB_TAG_TIMESTAMPS     0x0016
+#define CB_TAG_CBMEM_CONSOLE  0x0017
+#define CB_TAG_MRC_CACHE      0x0018
+struct cb_cbmem_tab {
+  UINT32    tag;
+  UINT32    size;
+  UINT64    cbmem_tab;
+};
+
+#define CB_TAG_SMMSTOREV2  0x0039
+struct cb_smmstorev2 {
+  UINT32    tag;
+  UINT32    size;
+  UINT32    num_blocks;      /* Number of writeable blocks in Smm */
+  UINT32    block_size;      /* Size of a block in byte. Default: 64 KiB */
+  UINT32    mmap_addr;       /* MMIO address of the store for read only access */
+  UINT32    com_buffer;      /* Physical address of the communication buffer */
+  UINT32    com_buffer_size; /* Size of the communication buffer in byte */
+  UINT8     apm_cmd;         /* The command byte to write to the APM I/O port */
+  UINT8     unused[3];       /* Set to zero */
+};
+
+/* Helpful macros */
+
+#define MEM_RANGE_COUNT(_rec) \
+  (((_rec)->size - sizeof(*(_rec))) / sizeof((_rec)->map[0]))
+
+#define MEM_RANGE_PTR(_rec, _idx) \
+  (void *)(((UINT8 *) (_rec)) + sizeof(*(_rec)) \
+    + (sizeof((_rec)->map[0]) * (_idx)))
+
+typedef struct cb_memory CB_MEMORY;
+
+#endif // _COREBOOT_PEI_H_INCLUDED_

--- a/Bootloader/coreboot/Include/Guid/SmmStoreInfoGuid.h
+++ b/Bootloader/coreboot/Include/Guid/SmmStoreInfoGuid.h
@@ -1,0 +1,27 @@
+/** @file
+  This file defines the hob structure for coreboot's SmmStore.
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMMSTORE_GUID_H_
+#define SMMSTORE_GUID_H_
+
+///
+/// System Table Information GUID
+///
+extern EFI_GUID  gEfiSmmStoreInfoHobGuid;
+
+typedef struct {
+  UINT64    ComBuffer;
+  UINT32    ComBufferSize;
+  UINT32    NumBlocks;
+  UINT32    BlockSize;
+  UINT64    MmioAddress;
+  UINT8     ApmCmd;
+  UINT8     Reserved0[3];
+} SMMSTORE_INFO;
+
+#endif // SMMSTORE_GUID_H_

--- a/Bootloader/coreboot/Include/Library/SmmStoreLib.h
+++ b/Bootloader/coreboot/Include/Library/SmmStoreLib.h
@@ -1,0 +1,120 @@
+/** @file  SmmStoreLib.h
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_STORE_LIB_H_
+#define SMM_STORE_LIB_H_
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Guid/SmmStoreInfoGuid.h>
+
+#define SMMSTORE_COMBUF_SIZE  16
+
+/**
+  Get the SmmStore block size
+
+  @param BlockSize    The pointer to store the block size in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetBlockSize (
+  OUT UINTN  *BlockSize
+  );
+
+/**
+  Get the SmmStore number of blocks
+
+  @param NumBlocks    The pointer to store the number of blocks in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetNumBlocks (
+  OUT UINTN  *NumBlocks
+  );
+
+/**
+  Get the SmmStore MMIO address
+
+  @param MmioAddress    The pointer to store the address in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetMmioAddress (
+  OUT EFI_PHYSICAL_ADDRESS  *MmioAddress
+  );
+
+/**
+  Read from SmmStore
+
+  @param[in] Lba      The starting logical block index to read from.
+  @param[in] Offset   Offset into the block at which to begin reading.
+  @param[in] NumBytes On input, indicates the requested read size. On
+                      output, indicates the actual number of bytes read
+  @param[in] Buffer   Pointer to the buffer to read into.
+
+**/
+EFI_STATUS
+SmmStoreLibRead (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  );
+
+/**
+  Write to SmmStore
+
+  @param[in] Lba      The starting logical block index to write to.
+  @param[in] Offset   Offset into the block at which to begin writing.
+  @param[in] NumBytes On input, indicates the requested write size. On
+                      output, indicates the actual number of bytes written
+  @param[in] Buffer   Pointer to the data to write.
+
+**/
+EFI_STATUS
+SmmStoreLibWrite (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  );
+
+/**
+  Erase a block using the SmmStore
+
+  @param Lba    The logical block index to erase.
+
+**/
+EFI_STATUS
+SmmStoreLibEraseBlock (
+  IN         EFI_LBA  Lba
+  );
+
+/**
+  Initializes SmmStore support
+
+  @retval EFI_WRITE_PROTECTED   The SmmStore is not present.
+  @retval EFI_UNSUPPORTED       The SmmStoreInfo HOB wasn't found.
+  @retval EFI_SUCCESS           The SmmStore is supported.
+
+**/
+EFI_STATUS
+SmmStoreLibInitialize (
+  VOID
+  );
+
+/**
+  Denitializes SmmStore support
+**/
+VOID
+EFIAPI
+SmmStoreLibDeinitialize (
+  VOID
+  );
+
+#endif /* SMM_STORE_LIB_H_ */

--- a/Bootloader/coreboot/Include/Library/SmmStoreParseLib.h
+++ b/Bootloader/coreboot/Include/Library/SmmStoreParseLib.h
@@ -1,0 +1,29 @@
+/** @file
+  This library will parse the coreboot table in memory and extract those required
+  information.
+
+  Copyright (c) 2021, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_STORE_PARSE_LIB_H_
+#define SMM_STORE_PARSE_LIB_H_
+
+#include <Guid/SmmStoreInfoGuid.h>
+
+/**
+  Find the SmmStore HOB.
+
+  @param  SmmStoreInfo       Pointer to the SMMSTORE_INFO structure
+
+  @retval RETURN_SUCCESS     Successfully find the Smm store buffer information.
+  @retval RETURN_NOT_FOUND   Failed to find the Smm store buffer information .
+**/
+RETURN_STATUS
+EFIAPI
+ParseSmmStoreInfo (
+  OUT SMMSTORE_INFO  *SmmStoreInfo
+  );
+
+#endif // SMM_STORE_PARSE_LIB_H_

--- a/Bootloader/coreboot/Library/CbParseLib/CbParseLib.c
+++ b/Bootloader/coreboot/Library/CbParseLib/CbParseLib.c
@@ -1,0 +1,649 @@
+/** @file
+  This library will parse the coreboot table in memory and extract those required
+  information.
+
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/IoLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/SmmStoreParseLib.h>
+#include <IndustryStandard/Acpi.h>
+#include <Coreboot.h>
+
+/**
+  Convert a packed value from cbuint64 to a UINT64 value.
+
+  @param  val      The pointer to packed data.
+
+  @return          the UNIT64 value after conversion.
+
+**/
+UINT64
+cb_unpack64 (
+  IN struct cbuint64  val
+  )
+{
+  return LShiftU64 (val.hi, 32) | val.lo;
+}
+
+/**
+  Returns the sum of all elements in a buffer of 16-bit values.  During
+  calculation, the carry bits are also been added.
+
+  @param  Buffer      The pointer to the buffer to carry out the sum operation.
+  @param  Length      The size, in bytes, of Buffer.
+
+  @return Sum         The sum of Buffer with carry bits included during additions.
+
+**/
+UINT16
+CbCheckSum16 (
+  IN UINT16  *Buffer,
+  IN UINTN   Length
+  )
+{
+  UINT32  Sum;
+  UINT32  TmpValue;
+  UINTN   Idx;
+  UINT8   *TmpPtr;
+
+  Sum    = 0;
+  TmpPtr = (UINT8 *)Buffer;
+  for (Idx = 0; Idx < Length; Idx++) {
+    TmpValue = TmpPtr[Idx];
+    if (Idx % 2 == 1) {
+      TmpValue <<= 8;
+    }
+
+    Sum += TmpValue;
+
+    // Wrap
+    if (Sum >= 0x10000) {
+      Sum = (Sum + (Sum >> 16)) & 0xFFFF;
+    }
+  }
+
+  return (UINT16)((~Sum) & 0xFFFF);
+}
+
+/**
+  Check the coreboot table if it is valid.
+
+  @param  Header            Pointer to coreboot table
+
+  @retval TRUE              The coreboot table is valid.
+  @retval Others            The coreboot table is not valid.
+
+**/
+BOOLEAN
+IsValidCbTable (
+  IN struct cb_header  *Header
+  )
+{
+  UINT16  CheckSum;
+
+  if ((Header == NULL) || (Header->table_bytes == 0)) {
+    return FALSE;
+  }
+
+  if (Header->signature != CB_HEADER_SIGNATURE) {
+    return FALSE;
+  }
+
+  //
+  // Check the checksum of the coreboot table header
+  //
+  CheckSum = CbCheckSum16 ((UINT16 *)Header, sizeof (*Header));
+  if (CheckSum != 0) {
+    DEBUG ((DEBUG_ERROR, "Invalid coreboot table header checksum\n"));
+    return FALSE;
+  }
+
+  CheckSum = CbCheckSum16 ((UINT16 *)((UINT8 *)Header + sizeof (*Header)), Header->table_bytes);
+  if (CheckSum != Header->table_checksum) {
+    DEBUG ((DEBUG_ERROR, "Incorrect checksum of all the coreboot table entries\n"));
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  This function retrieves the parameter base address from boot loader.
+
+  This function will get bootloader specific parameter address for UEFI payload.
+  e.g. HobList pointer for Slim Bootloader, and coreboot table header for Coreboot.
+
+  @retval NULL            Failed to find the GUID HOB.
+  @retval others          GUIDed HOB data pointer.
+
+**/
+VOID *
+EFIAPI
+GetParameterBase (
+  VOID
+  )
+{
+  struct cb_header  *Header;
+  struct cb_record  *Record;
+  UINT8             *TmpPtr;
+  UINT8             *CbTablePtr;
+  UINTN             Idx;
+  EFI_STATUS        Status;
+
+  //
+  // coreboot could pass coreboot table to UEFI payload
+  //
+  Header = (struct cb_header *)(UINTN)GET_BOOTLOADER_PARAMETER ();
+  if (IsValidCbTable (Header)) {
+    return Header;
+  }
+
+  //
+  // Find simplified coreboot table in memory range 0 ~ 4KB.
+  // Some GCC version does not allow directly access to NULL pointer,
+  // so start the search from 0x10 instead.
+  //
+  for (Idx = 16; Idx < 4096; Idx += 16) {
+    Header = (struct cb_header *)Idx;
+    if (Header->signature == CB_HEADER_SIGNATURE) {
+      break;
+    }
+  }
+
+  if (Idx >= 4096) {
+    return NULL;
+  }
+
+  //
+  // Check the coreboot header
+  //
+  if (!IsValidCbTable (Header)) {
+    return NULL;
+  }
+
+  //
+  // Find full coreboot table in high memory
+  //
+  CbTablePtr = NULL;
+  TmpPtr     = (UINT8 *)Header + Header->header_bytes;
+  for (Idx = 0; Idx < Header->table_entries; Idx++) {
+    Record = (struct cb_record *)TmpPtr;
+    if (Record->tag == CB_TAG_FORWARD) {
+      CbTablePtr = (VOID *)(UINTN)((struct cb_forward *)(UINTN)Record)->forward;
+      break;
+    }
+
+    TmpPtr += Record->size;
+  }
+
+  //
+  // Check the coreboot header in high memory
+  //
+  if (!IsValidCbTable ((struct cb_header *)CbTablePtr)) {
+    return NULL;
+  }
+
+  Status = PcdSet64S (PcdBootloaderParameter, (UINTN)CbTablePtr);
+  ASSERT_EFI_ERROR (Status);
+
+  return CbTablePtr;
+}
+
+/**
+  Find coreboot record with given Tag.
+
+  @param  Tag                The tag id to be found
+
+  @retval NULL              The Tag is not found.
+  @retval Others            The pointer to the record found.
+
+**/
+VOID *
+FindCbTag (
+  IN  UINT32  Tag
+  )
+{
+  struct cb_header  *Header;
+  struct cb_record  *Record;
+  UINT8             *TmpPtr;
+  UINT8             *TagPtr;
+  UINTN             Idx;
+
+  Header = (struct cb_header *)GetParameterBase ();
+
+  TagPtr = NULL;
+  TmpPtr = (UINT8 *)Header + Header->header_bytes;
+  for (Idx = 0; Idx < Header->table_entries; Idx++) {
+    Record = (struct cb_record *)TmpPtr;
+    if (Record->tag == Tag) {
+      TagPtr = TmpPtr;
+      break;
+    }
+
+    TmpPtr += Record->size;
+  }
+
+  return TagPtr;
+}
+
+/**
+  Find the given table with TableId from the given coreboot memory Root.
+
+  @param  Root               The coreboot memory table to be searched in
+  @param  TableId            Table id to be found
+  @param  MemTable           To save the base address of the memory table found
+  @param  MemTableSize       To save the size of memory table found
+
+  @retval RETURN_SUCCESS            Successfully find out the memory table.
+  @retval RETURN_INVALID_PARAMETER  Invalid input parameters.
+  @retval RETURN_NOT_FOUND          Failed to find the memory table.
+
+**/
+RETURN_STATUS
+FindCbMemTable (
+  IN  struct cbmem_root  *Root,
+  IN  UINT32             TableId,
+  OUT VOID               **MemTable,
+  OUT UINT32             *MemTableSize
+  )
+{
+  UINTN               Idx;
+  BOOLEAN             IsImdEntry;
+  struct cbmem_entry  *Entries;
+
+  if ((Root == NULL) || (MemTable == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  //
+  // Check if the entry is CBMEM or IMD
+  // and handle them separately
+  //
+  Entries = Root->entries;
+  if (Entries[0].magic == CBMEM_ENTRY_MAGIC) {
+    IsImdEntry = FALSE;
+  } else {
+    Entries = (struct cbmem_entry *)((struct imd_root *)Root)->entries;
+    if (Entries[0].magic == IMD_ENTRY_MAGIC) {
+      IsImdEntry = TRUE;
+    } else {
+      return RETURN_NOT_FOUND;
+    }
+  }
+
+  for (Idx = 0; Idx < Root->num_entries; Idx++) {
+    if (Entries[Idx].id == TableId) {
+      if (IsImdEntry) {
+        *MemTable = (VOID *)((UINTN)Entries[Idx].start + (UINTN)Root);
+      } else {
+        *MemTable = (VOID *)(UINTN)Entries[Idx].start;
+      }
+
+      if (MemTableSize != NULL) {
+        *MemTableSize = Entries[Idx].size;
+      }
+
+      DEBUG ((
+        DEBUG_INFO,
+        "Find CbMemTable Id 0x%x, base %p, size 0x%x\n",
+        TableId,
+        *MemTable,
+        Entries[Idx].size
+        ));
+      return RETURN_SUCCESS;
+    }
+  }
+
+  return RETURN_NOT_FOUND;
+}
+
+/**
+  Acquire the coreboot memory table with the given table id
+
+  @param  TableId            Table id to be searched
+  @param  MemTable           Pointer to the base address of the memory table
+  @param  MemTableSize       Pointer to the size of the memory table
+
+  @retval RETURN_SUCCESS     Successfully find out the memory table.
+  @retval RETURN_INVALID_PARAMETER  Invalid input parameters.
+  @retval RETURN_NOT_FOUND   Failed to find the memory table.
+
+**/
+RETURN_STATUS
+ParseCbMemTable (
+  IN  UINT32  TableId,
+  OUT VOID    **MemTable,
+  OUT UINT32  *MemTableSize
+  )
+{
+  EFI_STATUS              Status;
+  CB_MEMORY               *Rec;
+  struct cb_memory_range  *Range;
+  UINT64                  Start;
+  UINT64                  Size;
+  UINTN                   Index;
+  struct cbmem_root       *CbMemRoot;
+
+  if (MemTable == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  *MemTable = NULL;
+  Status    = RETURN_NOT_FOUND;
+
+  //
+  // Get the coreboot memory table
+  //
+  Rec = (CB_MEMORY *)FindCbTag (CB_TAG_MEMORY);
+  if (Rec == NULL) {
+    return Status;
+  }
+
+  for (Index = 0; Index < MEM_RANGE_COUNT (Rec); Index++) {
+    Range = MEM_RANGE_PTR (Rec, Index);
+    Start = cb_unpack64 (Range->start);
+    Size  = cb_unpack64 (Range->size);
+
+    if ((Range->type == CB_MEM_TABLE) && (Start > 0x1000)) {
+      CbMemRoot = (struct  cbmem_root *)(UINTN)(Start + Size - DYN_CBMEM_ALIGN_SIZE);
+      Status    = FindCbMemTable (CbMemRoot, TableId, MemTable, MemTableSize);
+      if (!EFI_ERROR (Status)) {
+        break;
+      }
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Acquire the memory information from the coreboot table in memory.
+
+  @param  MemInfoCallback     The callback routine
+  @param  Params              Pointer to the callback routine parameter
+
+  @retval RETURN_SUCCESS     Successfully find out the memory information.
+  @retval RETURN_NOT_FOUND   Failed to find the memory information.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseMemoryInfo (
+  IN  BL_MEM_INFO_CALLBACK  MemInfoCallback,
+  IN  VOID                  *Params
+  )
+{
+  CB_MEMORY               *Rec;
+  struct cb_memory_range  *Range;
+  UINTN                   Index;
+  MEMORY_MAP_ENTRY        MemoryMap;
+
+  //
+  // Get the coreboot memory table
+  //
+  Rec = (CB_MEMORY *)FindCbTag (CB_TAG_MEMORY);
+  if (Rec == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  for (Index = 0; Index < MEM_RANGE_COUNT (Rec); Index++) {
+    Range          = MEM_RANGE_PTR (Rec, Index);
+    MemoryMap.Base = cb_unpack64 (Range->start);
+    MemoryMap.Size = cb_unpack64 (Range->size);
+    MemoryMap.Type = (UINT8)Range->type;
+    MemoryMap.Flag = 0;
+    DEBUG ((
+      DEBUG_INFO,
+      "%d. %016lx - %016lx [%02x]\n",
+      Index,
+      MemoryMap.Base,
+      MemoryMap.Base + MemoryMap.Size - 1,
+      MemoryMap.Type
+      ));
+
+    MemInfoCallback (&MemoryMap, Params);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Acquire SMBIOS table from coreboot.
+
+  @param  SmbiosTable               Pointer to the SMBIOS table info.
+
+  @retval RETURN_SUCCESS            Successfully find out the tables.
+  @retval RETURN_NOT_FOUND          Failed to find the tables.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseSmbiosTable (
+  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *MemTable;
+  UINT32      MemTableSize;
+
+  Status = ParseCbMemTable (SIGNATURE_32 ('T', 'B', 'M', 'S'), &MemTable, &MemTableSize);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  SmbiosTable->SmBiosEntryPoint = (UINT64)(UINTN)MemTable;
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Acquire ACPI table from coreboot.
+
+  @param  AcpiTableHob              Pointer to the ACPI table info.
+
+  @retval RETURN_SUCCESS            Successfully find out the tables.
+  @retval RETURN_NOT_FOUND          Failed to find the tables.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseAcpiTableInfo (
+  OUT UNIVERSAL_PAYLOAD_ACPI_TABLE  *AcpiTableHob
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *MemTable;
+  UINT32      MemTableSize;
+
+  Status = ParseCbMemTable (SIGNATURE_32 ('I', 'P', 'C', 'A'), &MemTable, &MemTableSize);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  AcpiTableHob->Rsdp = (UINT64)(UINTN)MemTable;
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Find the serial port information
+
+  @param  SerialPortInfo     Pointer to serial port info structure
+
+  @retval RETURN_SUCCESS     Successfully find the serial port information.
+  @retval RETURN_NOT_FOUND   Failed to find the serial port information .
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseSerialInfo (
+  OUT SERIAL_PORT_INFO  *SerialPortInfo
+  )
+{
+  struct cb_serial  *CbSerial;
+
+  CbSerial = FindCbTag (CB_TAG_SERIAL);
+  if (CbSerial == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  SerialPortInfo->BaseAddr    = CbSerial->baseaddr;
+  SerialPortInfo->RegWidth    = CbSerial->regwidth;
+  SerialPortInfo->Type        = CbSerial->type;
+  SerialPortInfo->Baud        = CbSerial->baud;
+  SerialPortInfo->InputHertz  = CbSerial->input_hertz;
+  SerialPortInfo->UartPciAddr = CbSerial->uart_pci_addr;
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Find the video frame buffer information
+
+  @param  GfxInfo             Pointer to the EFI_PEI_GRAPHICS_INFO_HOB structure
+
+  @retval RETURN_SUCCESS     Successfully find the video frame buffer information.
+  @retval RETURN_NOT_FOUND   Failed to find the video frame buffer information .
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseGfxInfo (
+  OUT EFI_PEI_GRAPHICS_INFO_HOB  *GfxInfo
+  )
+{
+  struct cb_framebuffer                 *CbFbRec;
+  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *GfxMode;
+
+  if (GfxInfo == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  CbFbRec = FindCbTag (CB_TAG_FRAMEBUFFER);
+  if (CbFbRec == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_INFO, "Found coreboot video frame buffer information\n"));
+  DEBUG ((DEBUG_INFO, "physical_address: 0x%lx\n", CbFbRec->physical_address));
+  DEBUG ((DEBUG_INFO, "x_resolution: 0x%x\n", CbFbRec->x_resolution));
+  DEBUG ((DEBUG_INFO, "y_resolution: 0x%x\n", CbFbRec->y_resolution));
+  DEBUG ((DEBUG_INFO, "bits_per_pixel: 0x%x\n", CbFbRec->bits_per_pixel));
+  DEBUG ((DEBUG_INFO, "bytes_per_line: 0x%x\n", CbFbRec->bytes_per_line));
+
+  DEBUG ((DEBUG_INFO, "red_mask_size: 0x%x\n", CbFbRec->red_mask_size));
+  DEBUG ((DEBUG_INFO, "red_mask_pos: 0x%x\n", CbFbRec->red_mask_pos));
+  DEBUG ((DEBUG_INFO, "green_mask_size: 0x%x\n", CbFbRec->green_mask_size));
+  DEBUG ((DEBUG_INFO, "green_mask_pos: 0x%x\n", CbFbRec->green_mask_pos));
+  DEBUG ((DEBUG_INFO, "blue_mask_size: 0x%x\n", CbFbRec->blue_mask_size));
+  DEBUG ((DEBUG_INFO, "blue_mask_pos: 0x%x\n", CbFbRec->blue_mask_pos));
+  DEBUG ((DEBUG_INFO, "reserved_mask_size: 0x%x\n", CbFbRec->reserved_mask_size));
+  DEBUG ((DEBUG_INFO, "reserved_mask_pos: 0x%x\n", CbFbRec->reserved_mask_pos));
+
+  GfxMode                       = &GfxInfo->GraphicsMode;
+  GfxMode->Version              = 0;
+  GfxMode->HorizontalResolution = CbFbRec->x_resolution;
+  GfxMode->VerticalResolution   = CbFbRec->y_resolution;
+  GfxMode->PixelsPerScanLine    = (CbFbRec->bytes_per_line << 3) / CbFbRec->bits_per_pixel;
+  if ((CbFbRec->red_mask_pos == 0) && (CbFbRec->green_mask_pos == 8) && (CbFbRec->blue_mask_pos == 16)) {
+    GfxMode->PixelFormat = PixelRedGreenBlueReserved8BitPerColor;
+  } else if ((CbFbRec->blue_mask_pos == 0) && (CbFbRec->green_mask_pos == 8) && (CbFbRec->red_mask_pos == 16)) {
+    GfxMode->PixelFormat = PixelBlueGreenRedReserved8BitPerColor;
+  }
+
+  GfxMode->PixelInformation.RedMask      = ((1 << CbFbRec->red_mask_size)      - 1) << CbFbRec->red_mask_pos;
+  GfxMode->PixelInformation.GreenMask    = ((1 << CbFbRec->green_mask_size)    - 1) << CbFbRec->green_mask_pos;
+  GfxMode->PixelInformation.BlueMask     = ((1 << CbFbRec->blue_mask_size)     - 1) << CbFbRec->blue_mask_pos;
+  GfxMode->PixelInformation.ReservedMask = ((1 << CbFbRec->reserved_mask_size) - 1) << CbFbRec->reserved_mask_pos;
+
+  GfxInfo->FrameBufferBase = CbFbRec->physical_address;
+  GfxInfo->FrameBufferSize = CbFbRec->bytes_per_line *  CbFbRec->y_resolution;
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Find the video frame buffer device information
+
+  @param  GfxDeviceInfo      Pointer to the EFI_PEI_GRAPHICS_DEVICE_INFO_HOB structure
+
+  @retval RETURN_SUCCESS     Successfully find the video frame buffer information.
+  @retval RETURN_NOT_FOUND   Failed to find the video frame buffer information.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseGfxDeviceInfo (
+  OUT EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *GfxDeviceInfo
+  )
+{
+  return RETURN_NOT_FOUND;
+}
+
+/**
+  Parse and handle the misc info provided by bootloader
+
+  @retval RETURN_SUCCESS           The misc information was parsed successfully.
+  @retval RETURN_NOT_FOUND         Could not find required misc info.
+  @retval RETURN_OUT_OF_RESOURCES  Insufficant memory space.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseMiscInfo (
+  VOID
+  )
+{
+  return RETURN_SUCCESS;
+}
+
+/**
+  Find the SmmStore HOB.
+
+  @param  SmmStoreInfo       Pointer to the SMMSTORE_INFO structure
+
+  @retval RETURN_SUCCESS     Successfully find the Smm store buffer information.
+  @retval RETURN_NOT_FOUND   Failed to find the Smm store buffer information .
+**/
+RETURN_STATUS
+EFIAPI
+ParseSmmStoreInfo (
+  OUT SMMSTORE_INFO  *SmmStoreInfo
+  )
+{
+  struct cb_smmstorev2  *CbSSRec;
+
+  if (SmmStoreInfo == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  CbSSRec = FindCbTag (CB_TAG_SMMSTOREV2);
+  if (CbSSRec == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_INFO, "Found Smm Store information\n"));
+  DEBUG ((DEBUG_INFO, "block size: 0x%x\n", CbSSRec->block_size));
+  DEBUG ((DEBUG_INFO, "number of blocks: 0x%x\n", CbSSRec->num_blocks));
+  DEBUG ((DEBUG_INFO, "communication buffer: 0x%x\n", CbSSRec->com_buffer));
+  DEBUG ((DEBUG_INFO, "communication buffer size: 0x%x\n", CbSSRec->com_buffer_size));
+  DEBUG ((DEBUG_INFO, "MMIO address of store: 0x%x\n", CbSSRec->mmap_addr));
+
+  SmmStoreInfo->ComBuffer     = CbSSRec->com_buffer;
+  SmmStoreInfo->ComBufferSize = CbSSRec->com_buffer_size;
+  SmmStoreInfo->BlockSize     = CbSSRec->block_size;
+  SmmStoreInfo->NumBlocks     = CbSSRec->num_blocks;
+  SmmStoreInfo->MmioAddress   = CbSSRec->mmap_addr;
+  SmmStoreInfo->ApmCmd        = CbSSRec->apm_cmd;
+
+  return RETURN_SUCCESS;
+}

--- a/Bootloader/coreboot/Library/CbParseLib/CbParseLib.inf
+++ b/Bootloader/coreboot/Library/CbParseLib/CbParseLib.inf
@@ -1,0 +1,39 @@
+## @file
+#  Coreboot Table Parse Library.
+#
+#  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = CbParseLib
+  FILE_GUID                      = 49EDFC9E-5945-4386-9C0B-C9B60CD45BB1
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BlParseLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  CbParseLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  DebugLib
+  PcdLib
+
+[Pcd]
+  gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter

--- a/Bootloader/coreboot/Library/SmmStoreLib/SmmStore.c
+++ b/Bootloader/coreboot/Library/SmmStoreLib/SmmStore.c
@@ -1,0 +1,473 @@
+/** @file  SmmStore.c
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiDxe.h>
+
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DxeServicesTableLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiRuntimeLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmmStoreLib.h>
+#include "SmmStore.h"
+
+/*
+ * A memory buffer to place arguments in.
+ */
+STATIC SMM_STORE_COM_BUF     *mArgComBuf;
+STATIC EFI_PHYSICAL_ADDRESS  mArgComBufPhys;
+
+/*
+ * Metadata provided by the first stage bootloader.
+ */
+STATIC SMMSTORE_INFO  *mSmmStoreInfo;
+
+STATIC EFI_EVENT  mSmmStoreLibVirtualAddrChangeEvent;
+
+/**
+  Calls into SMM to use the SMMSTOREv2 implementation for persistent storage.
+
+  @param Cmd     The command to write into the APM port. This allows to enter the
+                 Smi special command handler.
+  @param SubCmd  The subcommand to execute in the Smi handler.
+  @param Arg     Optional argument to pass to the Smi handler. Typically a pointer
+                 in 'flat' memory mode, which points to read only memory.
+
+  @retval EFI_NO_RESPONSE       The SmmStore is not present or didn't response.
+  @retval EFI_UNSUPPORTED       The request isn't suppored.
+  @retval EFI_DEVICE_ERROR      An error occured while executing the request.
+  @retval EFI_SUCCESS           The operation was executed successfully.
+**/
+STATIC
+EFI_STATUS
+CallSmm (
+  UINT8  Cmd,
+  UINT8  SubCmd,
+  UINTN  Arg
+  )
+{
+  CONST UINTN  Rax = ((SubCmd << 8) | Cmd);
+  CONST UINTN  Rbx = Arg;
+  UINTN        Result;
+
+  Result = TriggerSmi (Rax, Rbx, 5);
+  if (Result == Rax) {
+    return EFI_NO_RESPONSE;
+  } else if (Result == SMMSTORE_RET_SUCCESS) {
+    return EFI_SUCCESS;
+  } else if (Result == SMMSTORE_RET_UNSUPPORTED) {
+    return EFI_UNSUPPORTED;
+  }
+
+  return EFI_DEVICE_ERROR;
+}
+
+/**
+  Get the SmmStore block size
+
+  @param BlockSize    The pointer to store the block size in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetBlockSize (
+  OUT UINTN  *BlockSize
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (BlockSize == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *BlockSize = mSmmStoreInfo->BlockSize;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get the SmmStore number of blocks
+
+  @param NumBlocks    The pointer to store the number of blocks in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetNumBlocks (
+  OUT UINTN  *NumBlocks
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (NumBlocks == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *NumBlocks = mSmmStoreInfo->NumBlocks;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get the SmmStore MMIO address
+
+  @param MmioAddress    The pointer to store the address in.
+
+**/
+EFI_STATUS
+SmmStoreLibGetMmioAddress (
+  OUT EFI_PHYSICAL_ADDRESS  *MmioAddress
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (MmioAddress == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *MmioAddress = mSmmStoreInfo->MmioAddress;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Read from SmmStore
+
+  @param[in] Lba      The starting logical block index to read from.
+  @param[in] Offset   Offset into the block at which to begin reading.
+  @param[in] NumBytes On input, indicates the requested read size. On
+                      output, indicates the actual number of bytes read
+  @param[in] Buffer   Pointer to the buffer to read into.
+
+**/
+EFI_STATUS
+SmmStoreLibRead (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (Lba >= mSmmStoreInfo->NumBlocks) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (((*NumBytes + Offset) > mSmmStoreInfo->BlockSize) ||
+      ((*NumBytes + Offset) > mSmmStoreInfo->ComBufferSize))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mArgComBuf->Read.BufSize   = *NumBytes;
+  mArgComBuf->Read.BufOffset = Offset;
+  mArgComBuf->Read.BlockId   = Lba;
+
+  Status = CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_READ, mArgComBufPhys);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  CopyMem (Buffer, (VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), *NumBytes);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Write to SmmStore
+
+  @param[in] Lba      The starting logical block index to write to.
+  @param[in] Offset   Offset into the block at which to begin writing.
+  @param[in] NumBytes On input, indicates the requested write size. On
+                      output, indicates the actual number of bytes written
+  @param[in] Buffer   Pointer to the data to write.
+
+**/
+EFI_STATUS
+SmmStoreLibWrite (
+  IN        EFI_LBA  Lba,
+  IN        UINTN    Offset,
+  IN        UINTN    *NumBytes,
+  IN        UINT8    *Buffer
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (Lba >= mSmmStoreInfo->NumBlocks) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (((*NumBytes + Offset) > mSmmStoreInfo->BlockSize) ||
+      ((*NumBytes + Offset) > mSmmStoreInfo->ComBufferSize))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mArgComBuf->Write.BufSize   = *NumBytes;
+  mArgComBuf->Write.BufOffset = Offset;
+  mArgComBuf->Write.BlockId   = Lba;
+
+  CopyMem ((VOID *)(UINTN)(mSmmStoreInfo->ComBuffer + Offset), Buffer, *NumBytes);
+
+  return CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_WRITE, mArgComBufPhys);
+}
+
+/**
+  Erase a SmmStore block
+
+  @param Lba    The logical block index to erase.
+
+**/
+EFI_STATUS
+SmmStoreLibEraseBlock (
+  IN   EFI_LBA  Lba
+  )
+{
+  if (mSmmStoreInfo == NULL) {
+    return EFI_NO_MEDIA;
+  }
+
+  if (Lba >= mSmmStoreInfo->NumBlocks) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  mArgComBuf->Clear.BlockId = Lba;
+
+  return CallSmm (mSmmStoreInfo->ApmCmd, SMMSTORE_CMD_RAW_CLEAR, mArgComBufPhys);
+}
+
+/**
+  Fixup internal data so that EFI can be call in virtual mode.
+  Call the passed in Child Notify event and convert any pointers in
+  lib to virtual mode.
+
+  @param[in]    Event   The Event that is being processed
+  @param[in]    Context Event Context
+**/
+STATIC
+VOID
+EFIAPI
+SmmStoreLibVirtualNotifyEvent (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EfiConvertPointer (0x0, (VOID **)&mArgComBuf);
+  if (mSmmStoreInfo != NULL) {
+    EfiConvertPointer (0x0, (VOID **)&mSmmStoreInfo->ComBuffer);
+    EfiConvertPointer (0x0, (VOID **)&mSmmStoreInfo);
+  }
+
+  return;
+}
+
+/**
+  Initializes SmmStore support
+
+  @retval EFI_WRITE_PROTECTED   The SmmStore is not present.
+  @retval EFI_OUT_OF_RESOURCES  Run out of memory.
+  @retval EFI_SUCCESS           The SmmStore is supported.
+
+**/
+EFI_STATUS
+SmmStoreLibInitialize (
+  VOID
+  )
+{
+  EFI_STATUS                       Status;
+  VOID                             *GuidHob;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
+
+  //
+  // Find the SmmStore information guid hob
+  //
+  GuidHob = GetFirstGuidHob (&gEfiSmmStoreInfoHobGuid);
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_WARN, "SmmStore not supported! Skipping driver init.\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Place SmmStore information hob in a runtime buffer
+  //
+  mSmmStoreInfo = AllocateRuntimePool (GET_GUID_HOB_DATA_SIZE (GuidHob));
+  if (mSmmStoreInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (mSmmStoreInfo, GET_GUID_HOB_DATA (GuidHob), GET_GUID_HOB_DATA_SIZE (GuidHob));
+
+  //
+  // Validate input
+  //
+  if ((mSmmStoreInfo->MmioAddress == 0) ||
+      (mSmmStoreInfo->ComBuffer == 0) ||
+      (mSmmStoreInfo->BlockSize == 0) ||
+      (mSmmStoreInfo->NumBlocks == 0))
+  {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid data in SmmStore Info hob\n", __FUNCTION__));
+    FreePool (mSmmStoreInfo);
+    mSmmStoreInfo = NULL;
+    return EFI_WRITE_PROTECTED;
+  }
+
+  //
+  // Allocate Communication Buffer for arguments to pass to SMM.
+  // The argument com buffer is only read by SMM, but never written.
+  // The FVB data send/retrieved will be placed in a separate bootloader
+  // pre-allocated memory region, the ComBuffer.
+  //
+  if (mSmmStoreInfo->ComBuffer < BASE_4GB) {
+    //
+    // Assume that SMM handler is running in 32-bit mode when ComBuffer is
+    // is placed below BASE_4GB.
+    //
+    mArgComBufPhys = BASE_4GB - 1;
+  } else {
+    mArgComBufPhys = BASE_8EB - 1;
+  }
+
+  Status = gBS->AllocatePages (
+                  AllocateMaxAddress,
+                  EfiRuntimeServicesData,
+                  EFI_SIZE_TO_PAGES (sizeof (SMM_STORE_COM_BUF)),
+                  &mArgComBufPhys
+                  );
+
+  if (EFI_ERROR (Status)) {
+    FreePool (mSmmStoreInfo);
+    mSmmStoreInfo = NULL;
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mArgComBuf = (VOID *)mArgComBufPhys;
+
+  //
+  // Register for the virtual address change event
+  //
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_NOTIFY,
+                  SmmStoreLibVirtualNotifyEvent,
+                  NULL,
+                  &gEfiEventVirtualAddressChangeGuid,
+                  &mSmmStoreLibVirtualAddrChangeEvent
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Finally mark the SMM communication buffer provided by CB or SBL as runtime memory
+  //
+  Status = gDS->GetMemorySpaceDescriptor (mSmmStoreInfo->ComBuffer, &GcdDescriptor);
+  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeReserved)) {
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "%a: No memory space descriptor for com buffer found\n",
+       __FUNCTION__
+      )
+      );
+
+    //
+    // Add a new entry if not covered by existing mapping
+    //
+    Status = gDS->AddMemorySpace (
+                    EfiGcdMemoryTypeReserved,
+                    mSmmStoreInfo->ComBuffer,
+                    mSmmStoreInfo->ComBufferSize,
+                    EFI_MEMORY_WB | EFI_MEMORY_RUNTIME
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Mark as runtime service
+  //
+  Status = gDS->SetMemorySpaceAttributes (
+                  mSmmStoreInfo->ComBuffer,
+                  mSmmStoreInfo->ComBufferSize,
+                  EFI_MEMORY_RUNTIME
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Mark the memory mapped store as MMIO memory
+  //
+  Status = gDS->GetMemorySpaceDescriptor (mSmmStoreInfo->MmioAddress, &GcdDescriptor);
+  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo)) {
+    DEBUG (
+      (
+       DEBUG_INFO,
+       "%a: No memory space descriptor for com buffer found\n",
+       __FUNCTION__
+      )
+      );
+
+    //
+    // Add a new entry if not covered by existing mapping
+    //
+    Status = gDS->AddMemorySpace (
+                    EfiGcdMemoryTypeMemoryMappedIo,
+                    mSmmStoreInfo->MmioAddress,
+                    mSmmStoreInfo->NumBlocks * mSmmStoreInfo->BlockSize,
+                    EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Mark as runtime service
+  //
+  Status = gDS->SetMemorySpaceAttributes (
+                  mSmmStoreInfo->MmioAddress,
+                  mSmmStoreInfo->NumBlocks * mSmmStoreInfo->BlockSize,
+                  EFI_MEMORY_RUNTIME
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Denitializes SmmStore support by freeing allocated memory and unregistering
+  the virtual address change event.
+**/
+VOID
+EFIAPI
+SmmStoreLibDeinitialize (
+  VOID
+  )
+{
+  if (mArgComBuf != NULL) {
+    gBS->FreePages (mArgComBufPhys, EFI_SIZE_TO_PAGES (sizeof (SMM_STORE_COM_BUF)));
+    mArgComBuf = NULL;
+  }
+
+  if (mSmmStoreInfo != NULL) {
+    FreePool (mSmmStoreInfo);
+    mSmmStoreInfo = NULL;
+  }
+
+  if (mSmmStoreLibVirtualAddrChangeEvent != NULL) {
+    gBS->CloseEvent (mSmmStoreLibVirtualAddrChangeEvent);
+    mSmmStoreLibVirtualAddrChangeEvent = NULL;
+  }
+}

--- a/Bootloader/coreboot/Library/SmmStoreLib/SmmStore.h
+++ b/Bootloader/coreboot/Library/SmmStoreLib/SmmStore.h
@@ -1,0 +1,81 @@
+/** @file  SmmStore.h
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef COREBOOT_SMMSTORE_H_
+#define COREBOOT_SMMSTORE_H_
+
+#define SMMSTORE_RET_SUCCESS      0
+#define SMMSTORE_RET_FAILURE      1
+#define SMMSTORE_RET_UNSUPPORTED  2
+
+/* Version 2 only */
+#define SMMSTORE_CMD_INIT       4
+#define SMMSTORE_CMD_RAW_READ   5
+#define SMMSTORE_CMD_RAW_WRITE  6
+#define SMMSTORE_CMD_RAW_CLEAR  7
+
+/*
+ * This allows the payload to store raw data in the flash regions.
+ * This can be used by a FaultTolerantWrite implementation, that uses at least
+ * two regions in an A/B update scheme.
+ */
+
+#pragma pack(1)
+
+/*
+ * Reads a chunk of raw data with size BufSize from the block specified by
+ * block_id starting at BufOffset.
+ * The read data is placed in buf.
+ *
+ * block_id must be less than num_blocks
+ * BufOffset + BufSize must be less than block_size
+ */
+typedef struct {
+  UINT32    BufSize;
+  UINT32    BufOffset;
+  UINT32    BlockId;
+} SMM_STORE_PARAMS_WRITE;
+
+/*
+ * Writes a chunk of raw data with size BufSize to the block specified by
+ * block_id starting at BufOffset.
+ *
+ * block_id must be less than num_blocks
+ * BufOffset + BufSize must be less than block_size
+ */
+typedef struct {
+  UINT32    BufSize;
+  UINT32    BufOffset;
+  UINT32    BlockId;
+} SMM_STORE_PARAMS_READ;
+
+/*
+ * Erases the specified block.
+ *
+ * block_id must be less than num_blocks
+ */
+typedef struct {
+  UINT32    BlockId;
+} SMM_STORE_PARAMS_CLEAR;
+
+typedef union {
+  SMM_STORE_PARAMS_WRITE    Write;
+  SMM_STORE_PARAMS_READ     Read;
+  SMM_STORE_PARAMS_CLEAR    Clear;
+} SMM_STORE_COM_BUF;
+#pragma pack(0)
+
+UINTN
+EFIAPI
+TriggerSmi (
+  IN UINTN  Cmd,
+  IN UINTN  Arg,
+  IN UINTN  Retry
+  );
+
+#endif // COREBOOT_SMMSTORE_H_

--- a/Bootloader/coreboot/Library/SmmStoreLib/SmmStoreLib.inf
+++ b/Bootloader/coreboot/Library/SmmStoreLib/SmmStoreLib.inf
@@ -1,0 +1,41 @@
+## @file
+#  SmmStore library for coreboot
+#
+#  Copyright (c) 2022 9elements GmbH.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmStoreLib
+  FILE_GUID                      = 40A2CBC6-CFB8-447b-A90E-298E88FD345E
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmmStoreLib
+
+[Sources]
+  SmmStore.c
+  SmmStore.h
+
+[Sources.X64]
+  X64/SmmStore.nasm
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  DxeServicesTableLib
+  HobLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiRuntimeLib
+
+[Guids]
+  gEfiSmmStoreInfoHobGuid           ## CONSUMES
+  gEfiEventVirtualAddressChangeGuid ## CONSUMES
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec

--- a/Bootloader/coreboot/Library/SmmStoreLib/X64/SmmStore.nasm
+++ b/Bootloader/coreboot/Library/SmmStoreLib/X64/SmmStore.nasm
@@ -1,0 +1,48 @@
+;------------------------------------------------------------------------------ ;
+; Copyright (c) 2022, 9elements GmbH. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;-------------------------------------------------------------------------------
+
+%include "Nasm.inc"
+
+DEFAULT REL
+SECTION .text
+
+;UINTN
+;EFIAPI
+;TriggerSmi (
+;  UINTN   Cmd,
+;  UINTN   Arg,
+;  UINTN   Retry
+;  )
+
+global ASM_PFX(TriggerSmi)
+ASM_PFX(TriggerSmi):
+    push    rbx
+    mov     rax, rcx                    ; Smi handler expect Cmd in RAX
+    mov     rbx, rdx                    ; Smi handler expect Argument in RBX
+@Trigger:
+    out     0b2h, al                    ; write to APM port to trigger SMI
+
+; There might ba a delay between writing the Smi trigger register and
+; entering SMM, in which case the Smi handler will do nothing as only
+; synchronous Smis are handled. In addition when there's no Smi handler
+; or the SmmStore feature isn't compiled in, no register will be modified.
+
+; As there's no livesign from SMM, just wait a bit for the handler to fire,
+; and then try again.
+
+    cmp     rax, rcx                    ; Check if rax was modified by SMM
+    jne     @Return                     ; SMM modified rax, return now
+    push    rcx                         ; save rcx to stack
+    mov     rcx, 10000
+    rep     pause                       ; add a small delay
+    pop     rcx                         ; restore rcx
+    cmp     r8, 0
+    je      @Return
+    dec     r8
+    jmp     @Trigger
+@Return:
+    pop     rbx
+    ret

--- a/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntime.c
+++ b/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntime.c
@@ -1,0 +1,282 @@
+/** @file  SmmStoreFvbRuntime.c
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/UefiLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DxeServicesTableLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SmmStoreLib.h>
+
+#include "SmmStoreFvbRuntime.h"
+
+STATIC EFI_EVENT  mSmmStoreVirtualAddrChangeEvent;
+
+//
+// Global variable declarations
+//
+SMMSTORE_INSTANCE  *mSmmStoreInstance;
+
+SMMSTORE_INSTANCE  mSmmStoreInstanceTemplate = {
+  SMMSTORE_SIGNATURE, // Signature
+  NULL,               // Handle ... NEED TO BE FILLED
+  {
+    FvbGetAttributes,      // GetAttributes
+    FvbSetAttributes,      // SetAttributes
+    FvbGetPhysicalAddress, // GetPhysicalAddress
+    FvbGetBlockSize,       // GetBlockSize
+    FvbRead,               // Read
+    FvbWrite,              // Write
+    FvbEraseBlocks,        // EraseBlocks
+    NULL,                  // ParentHandle
+  }, //  FvbProtoccol
+  0, // BlockSize ... NEED TO BE FILLED
+  0, // LastBlock ... NEED TO BE FILLED
+  0, // MmioAddress ... NEED TO BE FILLED
+  {
+    {
+      {
+        HARDWARE_DEVICE_PATH,
+        HW_MEMMAP_DP,
+        {
+          (UINT8)(sizeof (MEMMAP_DEVICE_PATH)),
+          (UINT8)(sizeof (MEMMAP_DEVICE_PATH) >> 8)
+        }
+      },
+      EfiMemoryMappedIO,
+      (EFI_PHYSICAL_ADDRESS)0, // NEED TO BE FILLED
+      (EFI_PHYSICAL_ADDRESS)0, // NEED TO BE FILLED
+    },
+    {
+      END_DEVICE_PATH_TYPE,
+      END_ENTIRE_DEVICE_PATH_SUBTYPE,
+      {
+        END_DEVICE_PATH_LENGTH,
+        0
+      }
+    }
+  } // DevicePath
+};
+
+/**
+  Initialize the SmmStore instance.
+
+
+  @param[in]      FvBase         The physical MMIO base address of the FV containing
+                                 the variable store.
+
+  @param[in]      NumberofBlocks Number of blocks within the FV.
+  @param[in]      BlockSize      The size in bytes of one block within the FV.
+  @param[in, out] Instance       The SmmStore instace to initialize
+
+**/
+STATIC
+EFI_STATUS
+SmmStoreInitInstance (
+  IN EFI_PHYSICAL_ADDRESS   FvBase,
+  IN UINTN                  NumberofBlocks,
+  IN UINTN                  BlockSize,
+  IN OUT SMMSTORE_INSTANCE  *Instance
+  )
+{
+  EFI_STATUS             Status;
+  FV_MEMMAP_DEVICE_PATH  *FvDevicePath;
+
+  ASSERT (Instance != NULL);
+
+  Instance->BlockSize   = BlockSize;
+  Instance->LastBlock   = NumberofBlocks - 1;
+  Instance->MmioAddress = FvBase;
+
+  FvDevicePath                                = &Instance->DevicePath;
+  FvDevicePath->MemMapDevPath.StartingAddress = FvBase;
+  FvDevicePath->MemMapDevPath.EndingAddress   = FvBase + BlockSize * NumberofBlocks - 1;
+
+  Status = FvbInitialize (Instance);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Instance->Handle,
+                  &gEfiDevicePathProtocolGuid,
+                  &Instance->DevicePath,
+                  &gEfiFirmwareVolumeBlockProtocolGuid,
+                  &Instance->FvbProtocol,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "%a: Created a new instance\n", __FUNCTION__));
+
+  return Status;
+}
+
+/**
+  Fixup internal data so that EFI can be call in virtual mode.
+  Call the passed in Child Notify event and convert any pointers in
+  lib to virtual mode.
+
+  @param[in]    Event   The Event that is being processed
+  @param[in]    Context Event Context
+**/
+STATIC
+VOID
+EFIAPI
+SmmStoreVirtualNotifyEvent (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  // Convert Fvb
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.EraseBlocks);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.GetAttributes);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.GetBlockSize);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.GetPhysicalAddress);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.Read);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.SetAttributes);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->FvbProtocol.Write);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance->MmioAddress);
+  EfiConvertPointer (0x0, (VOID **)&mSmmStoreInstance);
+
+  return;
+}
+
+/**
+  The user Entry Point for module SmmStoreFvbRuntimeDxe. The user code starts with this function.
+
+  @param[in] ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in] SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS       The entry point is executed successfully.
+  @retval other             Some error occurs when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+SmmStoreInitialize (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  MmioAddress;
+  UINTN                 BlockSize;
+  UINTN                 BlockCount;
+  UINT32                NvStorageBase;
+  UINT32                NvStorageSize;
+  UINT32                NvVariableSize;
+  UINT32                FtwWorkingSize;
+  UINT32                FtwSpareSize;
+
+  Status = SmmStoreLibInitialize ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to initialize SmmStoreLib\n", __FUNCTION__));
+    return Status;
+  }
+
+  Status = SmmStoreLibGetMmioAddress (&MmioAddress);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get SmmStore MMIO address\n", __FUNCTION__));
+    SmmStoreLibDeinitialize ();
+    return Status;
+  }
+
+  Status = SmmStoreLibGetNumBlocks (&BlockCount);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get SmmStore No. blocks\n", __FUNCTION__));
+    SmmStoreLibDeinitialize ();
+    return Status;
+  }
+
+  Status = SmmStoreLibGetBlockSize (&BlockSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get SmmStore block size\n", __FUNCTION__));
+    SmmStoreLibDeinitialize ();
+    return Status;
+  }
+
+  NvStorageSize = BlockCount * BlockSize;
+  NvStorageBase = MmioAddress;
+
+  FtwSpareSize   = (BlockCount / 2) * BlockSize;
+  FtwWorkingSize = BlockSize;
+  NvVariableSize = NvStorageSize - FtwSpareSize - FtwWorkingSize;
+  DEBUG ((DEBUG_INFO, "NvStorageBase:0x%x, NvStorageSize:0x%x\n", NvStorageBase, NvStorageSize));
+
+  if (NvVariableSize >= 0x80000000) {
+    SmmStoreLibDeinitialize ();
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = PcdSet32S (PcdFlashNvStorageVariableSize, NvVariableSize);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet32S (PcdFlashNvStorageVariableBase, NvStorageBase);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet64S (PcdFlashNvStorageVariableBase64, NvStorageBase);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = PcdSet32S (PcdFlashNvStorageFtwWorkingSize, FtwWorkingSize);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet32S (PcdFlashNvStorageFtwWorkingBase, NvStorageBase + NvVariableSize);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet64S (PcdFlashNvStorageFtwWorkingBase64, NvStorageBase + NvVariableSize);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = PcdSet32S (PcdFlashNvStorageFtwSpareSize, FtwSpareSize);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet32S (PcdFlashNvStorageFtwSpareBase, NvStorageBase + NvVariableSize + FtwWorkingSize);
+  ASSERT_EFI_ERROR (Status);
+  Status = PcdSet64S (PcdFlashNvStorageFtwSpareBase64, NvStorageBase + NvVariableSize + FtwWorkingSize);
+  ASSERT_EFI_ERROR (Status);
+
+  mSmmStoreInstance = AllocateRuntimeCopyPool (sizeof (SMMSTORE_INSTANCE), &mSmmStoreInstanceTemplate);
+  if (mSmmStoreInstance == NULL) {
+    SmmStoreLibDeinitialize ();
+    DEBUG ((DEBUG_ERROR, "%a: Out of resources\n", __FUNCTION__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = SmmStoreInitInstance (
+             MmioAddress,
+             BlockCount,
+             BlockSize,
+             mSmmStoreInstance
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG (
+      (
+       DEBUG_ERROR,
+       "%a: Fail to create instance for SmmStore\n",
+       __FUNCTION__
+      )
+      );
+    FreePool (mSmmStoreInstance);
+    SmmStoreLibDeinitialize ();
+    return Status;
+  }
+
+  //
+  // Register for the virtual address change event
+  //
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_NOTIFY,
+                  SmmStoreVirtualNotifyEvent,
+                  NULL,
+                  &gEfiEventVirtualAddressChangeGuid,
+                  &mSmmStoreVirtualAddrChangeEvent
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntime.h
+++ b/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntime.h
@@ -1,0 +1,111 @@
+/** @file  SmmStoreFvbRuntime.h
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_STORE_DXE_H_
+#define SMM_STORE_DXE_H_
+
+#include <Base.h>
+#include <PiDxe.h>
+
+#include <Guid/EventGroup.h>
+
+#include <Protocol/FirmwareVolumeBlock.h>
+
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiRuntimeLib.h>
+
+#define SMMSTORE_SIGNATURE  SIGNATURE_32('S', 'M', 'M', 'S')
+#define INSTANCE_FROM_FVB_THIS(a)  CR(a, SMMSTORE_INSTANCE, FvbProtocol, SMMSTORE_SIGNATURE)
+
+typedef struct _SMMSTORE_INSTANCE SMMSTORE_INSTANCE;
+
+typedef struct {
+  MEMMAP_DEVICE_PATH          MemMapDevPath;
+  EFI_DEVICE_PATH_PROTOCOL    EndDevPath;
+} FV_MEMMAP_DEVICE_PATH;
+
+struct _SMMSTORE_INSTANCE {
+  UINT32                                 Signature;
+  EFI_HANDLE                             Handle;
+  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL    FvbProtocol;
+  UINTN                                  BlockSize;
+  UINTN                                  LastBlock;
+  EFI_PHYSICAL_ADDRESS                   MmioAddress;
+  FV_MEMMAP_DEVICE_PATH                  DevicePath;
+};
+
+//
+// SmmStoreFvbRuntimeDxe.c
+//
+
+EFI_STATUS
+EFIAPI
+FvbInitialize (
+  IN SMMSTORE_INSTANCE  *Instance
+  );
+
+EFI_STATUS
+EFIAPI
+FvbGetAttributes (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  OUT       EFI_FVB_ATTRIBUTES_2                 *Attributes
+  );
+
+EFI_STATUS
+EFIAPI
+FvbSetAttributes (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN OUT    EFI_FVB_ATTRIBUTES_2                 *Attributes
+  );
+
+EFI_STATUS
+EFIAPI
+FvbGetPhysicalAddress (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  OUT       EFI_PHYSICAL_ADDRESS                 *Address
+  );
+
+EFI_STATUS
+EFIAPI
+FvbGetBlockSize (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  OUT       UINTN                                *BlockSize,
+  OUT       UINTN                                *NumberOfBlocks
+  );
+
+EFI_STATUS
+EFIAPI
+FvbRead (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  IN        UINTN                                Offset,
+  IN OUT    UINTN                                *NumBytes,
+  IN OUT    UINT8                                *Buffer
+  );
+
+EFI_STATUS
+EFIAPI
+FvbWrite (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  IN        UINTN                                Offset,
+  IN OUT    UINTN                                *NumBytes,
+  IN        UINT8                                *Buffer
+  );
+
+EFI_STATUS
+EFIAPI
+FvbEraseBlocks (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  ...
+  );
+
+#endif // SMM_STORE_DXE_H_

--- a/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntimeDxe.c
+++ b/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntimeDxe.c
@@ -1,0 +1,849 @@
+/** @file  SmmStoreFvbRuntimeDxe.c
+
+  Copyright (c) 2022, 9elements GmbH<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include <Library/PcdLib.h>
+#include <Library/BaseLib.h>
+#include <Library/HobLib.h>
+#include <Library/UefiLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DxeServicesTableLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmmStoreLib.h>
+
+#include <Guid/VariableFormat.h>
+#include <Guid/SystemNvDataGuid.h>
+#include <Guid/NvVarStoreFormatted.h>
+
+#include "SmmStoreFvbRuntime.h"
+
+///
+/// The Firmware Volume Block Protocol is the low-level interface
+/// to a firmware volume. File-level access to a firmware volume
+/// should not be done using the Firmware Volume Block Protocol.
+/// Normal access to a firmware volume must use the Firmware
+/// Volume Protocol. Typically, only the file system driver that
+/// produces the Firmware Volume Protocol will bind to the
+/// Firmware Volume Block Protocol.
+///
+
+/**
+  Initialises the FV Header and Variable Store Header
+  to support variable operations.
+
+  @param[in]  Instance - Pointer to SmmStore instance
+
+**/
+EFI_STATUS
+InitializeFvAndVariableStoreHeaders (
+  IN SMMSTORE_INSTANCE  *Instance
+  )
+{
+  EFI_STATUS                  Status;
+  VOID                        *Headers;
+  UINTN                       HeadersLength;
+  EFI_FIRMWARE_VOLUME_HEADER  *FirmwareVolumeHeader;
+  VARIABLE_STORE_HEADER       *VariableStoreHeader;
+  UINT32                      NvStorageFtwSpareSize;
+  UINT32                      NvStorageFtwWorkingSize;
+  UINT32                      NvStorageVariableSize;
+  UINT64                      NvStorageFtwSpareBase;
+  UINT64                      NvStorageFtwWorkingBase;
+  UINT64                      NvStorageVariableBase;
+
+  HeadersLength = sizeof (EFI_FIRMWARE_VOLUME_HEADER) + sizeof (EFI_FV_BLOCK_MAP_ENTRY) + sizeof (VARIABLE_STORE_HEADER);
+  Headers       = AllocateZeroPool (HeadersLength);
+
+  NvStorageFtwWorkingSize = PcdGet32 (PcdFlashNvStorageFtwWorkingSize);
+  NvStorageFtwSpareSize   = PcdGet32 (PcdFlashNvStorageFtwSpareSize);
+  NvStorageVariableSize   = PcdGet32 (PcdFlashNvStorageVariableSize);
+
+  NvStorageFtwSpareBase = (PcdGet64 (PcdFlashNvStorageFtwSpareBase64) != 0) ?
+                          PcdGet64 (PcdFlashNvStorageFtwSpareBase64) : PcdGet32 (PcdFlashNvStorageFtwSpareBase);
+  NvStorageFtwWorkingBase = (PcdGet64 (PcdFlashNvStorageFtwWorkingBase64) != 0) ?
+                            PcdGet64 (PcdFlashNvStorageFtwWorkingBase64) : PcdGet32 (PcdFlashNvStorageFtwWorkingBase);
+  NvStorageVariableBase = (PcdGet64 (PcdFlashNvStorageVariableBase64) != 0) ?
+                          PcdGet64 (PcdFlashNvStorageVariableBase64) : PcdGet32 (PcdFlashNvStorageVariableBase);
+
+  // FirmwareVolumeHeader->FvLength is declared to have the Variable area AND the FTW working area AND the FTW Spare contiguous.
+  if ((NvStorageVariableBase + NvStorageVariableSize) != NvStorageFtwWorkingBase) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NvStorageFtwWorkingBase is not contiguous with NvStorageVariableBase region\n",
+      __FUNCTION__
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((NvStorageFtwWorkingBase + NvStorageFtwWorkingSize) != NvStorageFtwSpareBase) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NvStorageFtwSpareBase is not contiguous with NvStorageFtwWorkingBase region\n",
+      __FUNCTION__
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Check if the size of the area is at least one block size
+  if ((NvStorageVariableSize <= 0) || (NvStorageVariableSize / Instance->BlockSize <= 0)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NvStorageVariableSize is 0x%x, should be atleast one block size\n",
+      __FUNCTION__,
+      NvStorageVariableSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((NvStorageFtwWorkingSize <= 0) || (NvStorageFtwWorkingSize / Instance->BlockSize <= 0)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NvStorageFtwWorkingSize is 0x%x, should be atleast one block size\n",
+      __FUNCTION__,
+      NvStorageFtwWorkingSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((NvStorageFtwSpareSize <= 0) || (NvStorageFtwSpareSize / Instance->BlockSize <= 0)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: NvStorageFtwSpareSize is 0x%x, should be atleast one block size\n",
+      __FUNCTION__,
+      NvStorageFtwSpareSize
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Ensure the Variable area Base Addresses are aligned on a block size boundaries
+  if ((NvStorageVariableBase % Instance->BlockSize != 0) ||
+      (NvStorageFtwWorkingBase % Instance->BlockSize != 0) ||
+      (NvStorageFtwSpareBase % Instance->BlockSize != 0))
+  {
+    DEBUG ((DEBUG_ERROR, "%a: NvStorage Base addresses must be aligned to block size boundaries", __FUNCTION__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // EFI_FIRMWARE_VOLUME_HEADER
+  //
+  FirmwareVolumeHeader = (EFI_FIRMWARE_VOLUME_HEADER *)Headers;
+  CopyGuid (&FirmwareVolumeHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid);
+  FirmwareVolumeHeader->FvLength =
+    PcdGet32 (PcdFlashNvStorageVariableSize) +
+    PcdGet32 (PcdFlashNvStorageFtwWorkingSize) +
+    PcdGet32 (PcdFlashNvStorageFtwSpareSize);
+  FirmwareVolumeHeader->Signature  = EFI_FVH_SIGNATURE;
+  FirmwareVolumeHeader->Attributes = (EFI_FVB_ATTRIBUTES_2)(
+                                                            EFI_FVB2_READ_ENABLED_CAP   | // Reads may be enabled
+                                                            EFI_FVB2_READ_STATUS        | // Reads are currently enabled
+                                                            EFI_FVB2_STICKY_WRITE       | // A block erase is required to flip bits into EFI_FVB2_ERASE_POLARITY
+                                                            EFI_FVB2_MEMORY_MAPPED      | // It is memory mapped
+                                                            EFI_FVB2_ERASE_POLARITY     | // After erasure all bits take this value (i.e. '1')
+                                                            EFI_FVB2_WRITE_STATUS       | // Writes are currently enabled
+                                                            EFI_FVB2_WRITE_ENABLED_CAP    // Writes may be enabled
+                                                            );
+  FirmwareVolumeHeader->HeaderLength          = sizeof (EFI_FIRMWARE_VOLUME_HEADER) + sizeof (EFI_FV_BLOCK_MAP_ENTRY);
+  FirmwareVolumeHeader->Revision              = EFI_FVH_REVISION;
+  FirmwareVolumeHeader->BlockMap[0].NumBlocks = Instance->LastBlock + 1;
+  FirmwareVolumeHeader->BlockMap[0].Length    = Instance->BlockSize;
+  FirmwareVolumeHeader->BlockMap[1].NumBlocks = 0;
+  FirmwareVolumeHeader->BlockMap[1].Length    = 0;
+  FirmwareVolumeHeader->Checksum              = CalculateCheckSum16 ((UINT16 *)FirmwareVolumeHeader, FirmwareVolumeHeader->HeaderLength);
+
+  //
+  // VARIABLE_STORE_HEADER
+  //
+  VariableStoreHeader = (VARIABLE_STORE_HEADER *)((UINTN)Headers + FirmwareVolumeHeader->HeaderLength);
+  CopyGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid);
+  VariableStoreHeader->Size   = PcdGet32 (PcdFlashNvStorageVariableSize) - FirmwareVolumeHeader->HeaderLength;
+  VariableStoreHeader->Format = VARIABLE_STORE_FORMATTED;
+  VariableStoreHeader->State  = VARIABLE_STORE_HEALTHY;
+
+  // Install the combined super-header in the NorFlash
+  Status = FvbWrite (&Instance->FvbProtocol, 0, 0, &HeadersLength, Headers);
+
+  FreePool (Headers);
+  return Status;
+}
+
+/**
+  Check the integrity of firmware volume header.
+
+  @retval  EFI_SUCCESS   - The firmware volume is consistent
+  @retval  EFI_NOT_FOUND - The firmware volume has been corrupted.
+
+**/
+EFI_STATUS
+ValidateFvHeader (
+  VOID
+  )
+{
+  UINT16                      Checksum;
+  EFI_FIRMWARE_VOLUME_HEADER  *FwVolHeader;
+  VARIABLE_STORE_HEADER       *VariableStoreHeader;
+  UINTN                       VariableStoreLength;
+  UINTN                       FvLength;
+  EFI_STATUS                  TempStatus;
+  UINTN                       BufferSize;
+  UINTN                       BufferSizeReqested;
+
+  BufferSizeReqested = sizeof (EFI_FIRMWARE_VOLUME_HEADER);
+  FwVolHeader        = (EFI_FIRMWARE_VOLUME_HEADER *)AllocatePool (BufferSizeReqested);
+  if (!FwVolHeader) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufferSize = BufferSizeReqested;
+  TempStatus = SmmStoreLibRead (0, 0, &BufferSize, (UINT8 *)FwVolHeader);
+  if (EFI_ERROR (TempStatus) || (BufferSizeReqested != BufferSize)) {
+    FreePool (FwVolHeader);
+    return EFI_DEVICE_ERROR;
+  }
+
+  FvLength = PcdGet32 (PcdFlashNvStorageVariableSize) + PcdGet32 (PcdFlashNvStorageFtwWorkingSize) +
+             PcdGet32 (PcdFlashNvStorageFtwSpareSize);
+
+  //
+  // Verify the header revision, header signature, length
+  // Length of FvBlock cannot be 2**64-1
+  // HeaderLength cannot be an odd number
+  //
+  if (  (FwVolHeader->Revision  != EFI_FVH_REVISION)
+     || (FwVolHeader->Signature != EFI_FVH_SIGNATURE)
+     || (FwVolHeader->FvLength  != FvLength)
+        )
+  {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: No Firmware Volume header present\n",
+      __FUNCTION__
+      ));
+    FreePool (FwVolHeader);
+    return EFI_NOT_FOUND;
+  }
+
+  // Check the Firmware Volume Guid
+  if ( CompareGuid (&FwVolHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid) == FALSE ) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Firmware Volume Guid non-compatible\n",
+      __FUNCTION__
+      ));
+    FreePool (FwVolHeader);
+    return EFI_NOT_FOUND;
+  }
+
+  BufferSizeReqested = FwVolHeader->HeaderLength;
+  FreePool (FwVolHeader);
+  FwVolHeader = (EFI_FIRMWARE_VOLUME_HEADER *)AllocatePool (BufferSizeReqested);
+  if (!FwVolHeader) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufferSize = BufferSizeReqested;
+  TempStatus = SmmStoreLibRead (0, 0, &BufferSize, (UINT8 *)FwVolHeader);
+  if (EFI_ERROR (TempStatus) || (BufferSizeReqested != BufferSize)) {
+    FreePool (FwVolHeader);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // Verify the header checksum
+  Checksum = CalculateSum16 ((UINT16 *)FwVolHeader, FwVolHeader->HeaderLength);
+  if (Checksum != 0) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: FV checksum is invalid (Checksum:0x%X)\n",
+      __FUNCTION__,
+      Checksum
+      ));
+    FreePool (FwVolHeader);
+    return EFI_NOT_FOUND;
+  }
+
+  BufferSizeReqested  = sizeof (VARIABLE_STORE_HEADER);
+  VariableStoreHeader = (VARIABLE_STORE_HEADER *)AllocatePool (BufferSizeReqested);
+  if (!VariableStoreHeader) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufferSize = BufferSizeReqested;
+  TempStatus = SmmStoreLibRead (0, FwVolHeader->HeaderLength, &BufferSize, (UINT8 *)VariableStoreHeader);
+  if (EFI_ERROR (TempStatus) || (BufferSizeReqested != BufferSize)) {
+    FreePool (VariableStoreHeader);
+    FreePool (FwVolHeader);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // Check the Variable Store Guid
+  if (!CompareGuid (&VariableStoreHeader->Signature, &gEfiVariableGuid) &&
+      !CompareGuid (&VariableStoreHeader->Signature, &gEfiAuthenticatedVariableGuid))
+  {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Variable Store Guid non-compatible\n",
+      __FUNCTION__
+      ));
+    FreePool (FwVolHeader);
+    FreePool (VariableStoreHeader);
+    return EFI_NOT_FOUND;
+  }
+
+  VariableStoreLength = PcdGet32 (PcdFlashNvStorageVariableSize) - FwVolHeader->HeaderLength;
+  if (VariableStoreHeader->Size != VariableStoreLength) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Variable Store Length does not match\n",
+      __FUNCTION__
+      ));
+    FreePool (FwVolHeader);
+    FreePool (VariableStoreHeader);
+    return EFI_NOT_FOUND;
+  }
+
+  FreePool (FwVolHeader);
+  FreePool (VariableStoreHeader);
+
+  return EFI_SUCCESS;
+}
+
+/**
+ The GetAttributes() function retrieves the attributes and
+ current settings of the block.
+
+ @param This         Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Attributes   Pointer to EFI_FVB_ATTRIBUTES_2 in which the attributes and
+                     current settings are returned.
+                     Type EFI_FVB_ATTRIBUTES_2 is defined in EFI_FIRMWARE_VOLUME_HEADER.
+
+ @retval EFI_SUCCESS The firmware volume attributes were returned.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbGetAttributes (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  OUT       EFI_FVB_ATTRIBUTES_2                 *Attributes
+  )
+{
+  EFI_FVB_ATTRIBUTES_2  FlashFvbAttributes;
+
+  FlashFvbAttributes = (EFI_FVB_ATTRIBUTES_2)(
+                                              EFI_FVB2_READ_STATUS      | // Reads are currently enabled
+                                              EFI_FVB2_WRITE_STATUS     | // Writes are enabled
+                                              EFI_FVB2_STICKY_WRITE     | // A block erase is required to flip bits into EFI_FVB2_ERASE_POLARITY
+                                              EFI_FVB2_MEMORY_MAPPED    | // It is memory mapped
+                                              EFI_FVB2_ERASE_POLARITY     // After erasure all bits take this value (i.e. '1')
+                                              );
+
+  *Attributes = FlashFvbAttributes;
+
+  DEBUG ((DEBUG_BLKIO, "FvbGetAttributes(0x%X)\n", *Attributes));
+
+  return EFI_SUCCESS;
+}
+
+/**
+ The SetAttributes() function sets configurable firmware volume attributes
+ and returns the new settings of the firmware volume.
+
+
+ @param This                     Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Attributes               On input, Attributes is a pointer to EFI_FVB_ATTRIBUTES_2
+                                 that contains the desired firmware volume settings.
+                                 On successful return, it contains the new settings of
+                                 the firmware volume.
+                                 Type EFI_FVB_ATTRIBUTES_2 is defined in EFI_FIRMWARE_VOLUME_HEADER.
+
+ @retval EFI_SUCCESS             The firmware volume attributes were returned.
+
+ @retval EFI_INVALID_PARAMETER   The attributes requested are in conflict with the capabilities
+                                 as declared in the firmware volume header.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbSetAttributes (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN OUT    EFI_FVB_ATTRIBUTES_2                 *Attributes
+  )
+{
+  DEBUG ((DEBUG_ERROR, "FvbSetAttributes(0x%X) is not supported\n", *Attributes));
+  return EFI_UNSUPPORTED;
+}
+
+/**
+ The GetPhysicalAddress() function retrieves the base address of
+ a memory-mapped firmware volume. This function should be called
+ only for memory-mapped firmware volumes.
+
+ @param This               Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Address            Pointer to a caller-allocated
+                           EFI_PHYSICAL_ADDRESS that, on successful
+                           return from GetPhysicalAddress(), contains the
+                           base address of the firmware volume.
+
+ @retval EFI_SUCCESS       The firmware volume base address was returned.
+
+ @retval EFI_NOT_SUPPORTED The firmware volume is not memory mapped.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbGetPhysicalAddress (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  OUT       EFI_PHYSICAL_ADDRESS                 *Address
+  )
+{
+  SMMSTORE_INSTANCE  *Instance;
+
+  Instance = INSTANCE_FROM_FVB_THIS (This);
+
+  ASSERT (Address != NULL);
+  *Address = Instance->MmioAddress;
+
+  return EFI_SUCCESS;
+}
+
+/**
+ The GetBlockSize() function retrieves the size of the requested
+ block. It also returns the number of additional blocks with
+ the identical size. The GetBlockSize() function is used to
+ retrieve the block map (see EFI_FIRMWARE_VOLUME_HEADER).
+
+
+ @param This                     Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Lba                      Indicates the block for which to return the size.
+
+ @param BlockSize                Pointer to a caller-allocated UINTN in which
+                                 the size of the block is returned.
+
+ @param NumberOfBlocks           Pointer to a caller-allocated UINTN in
+                                 which the number of consecutive blocks,
+                                 starting with Lba, is returned. All
+                                 blocks in this range have a size of
+                                 BlockSize.
+
+
+ @retval EFI_SUCCESS             The firmware volume base address was returned.
+
+ @retval EFI_INVALID_PARAMETER   The requested LBA is out of range.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbGetBlockSize (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  OUT       UINTN                                *BlockSize,
+  OUT       UINTN                                *NumberOfBlocks
+  )
+{
+  EFI_STATUS         Status;
+  SMMSTORE_INSTANCE  *Instance;
+
+  Instance = INSTANCE_FROM_FVB_THIS (This);
+
+  DEBUG ((DEBUG_BLKIO, "FvbGetBlockSize(Lba=%ld, BlockSize=0x%x, LastBlock=%ld)\n", Lba, Instance->BlockSize, Instance->LastBlock));
+
+  if (Lba > Instance->LastBlock) {
+    DEBUG ((DEBUG_ERROR, "FvbGetBlockSize: ERROR - Parameter LBA %ld is beyond the last Lba (%ld).\n", Lba, Instance->LastBlock));
+    Status = EFI_INVALID_PARAMETER;
+  } else {
+    *BlockSize      = (UINTN)Instance->BlockSize;
+    *NumberOfBlocks = (UINTN)(Instance->LastBlock - Lba + 1);
+
+    DEBUG ((DEBUG_BLKIO, "FvbGetBlockSize: *BlockSize=0x%x, *NumberOfBlocks=0x%x.\n", *BlockSize, *NumberOfBlocks));
+
+    Status = EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+ Reads the specified number of bytes into a buffer from the specified block.
+
+ The Read() function reads the requested number of bytes from the
+ requested block and stores them in the provided buffer.
+ Implementations should be mindful that the firmware volume
+ might be in the ReadDisabled state. If it is in this state,
+ the Read() function must return the status code
+ EFI_ACCESS_DENIED without modifying the contents of the
+ buffer. The Read() function must also prevent spanning block
+ boundaries. If a read is requested that would span a block
+ boundary, the read must read up to the boundary but not
+ beyond. The output parameter NumBytes must be set to correctly
+ indicate the number of bytes actually read. The caller must be
+ aware that a read may be partially completed.
+
+ @param This                 Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Lba                  The starting logical block index from which to read.
+
+ @param Offset               Offset into the block at which to begin reading.
+
+ @param NumBytes             Pointer to a UINTN.
+                             At entry, *NumBytes contains the total size of the buffer.
+                             At exit, *NumBytes contains the total number of bytes read.
+
+ @param Buffer               Pointer to a caller-allocated buffer that will be used
+                             to hold the data that is read.
+
+ @retval EFI_SUCCESS         The firmware volume was read successfully,  and contents are
+                             in Buffer.
+
+ @retval EFI_BAD_BUFFER_SIZE Read attempted across an LBA boundary.
+                             On output, NumBytes contains the total number of bytes
+                             returned in Buffer.
+
+ @retval EFI_ACCESS_DENIED   The firmware volume is in the ReadDisabled state.
+
+ @retval EFI_DEVICE_ERROR    The block device is not functioning correctly and could not be read.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbRead (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  IN        UINTN                                Offset,
+  IN OUT    UINTN                                *NumBytes,
+  IN OUT    UINT8                                *Buffer
+  )
+{
+  UINTN              BlockSize;
+  SMMSTORE_INSTANCE  *Instance;
+
+  Instance = INSTANCE_FROM_FVB_THIS (This);
+
+  DEBUG ((DEBUG_BLKIO, "FvbRead(Parameters: Lba=%ld, Offset=0x%x, *NumBytes=0x%x, Buffer @ 0x%08x)\n", Lba, Offset, *NumBytes, Buffer));
+
+  // Cache the block size to avoid de-referencing pointers all the time
+  BlockSize = Instance->BlockSize;
+
+  // The read must not span block boundaries.
+  // We need to check each variable individually because adding two large values together overflows.
+  if ((Offset               >= BlockSize) ||
+      (*NumBytes            >  BlockSize) ||
+      ((Offset + *NumBytes) >  BlockSize))
+  {
+    DEBUG ((DEBUG_ERROR, "FvbRead: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  // We must have some bytes to read
+  if (*NumBytes == 0) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  return SmmStoreLibRead (Lba, Offset, NumBytes, Buffer);
+}
+
+/**
+ Writes the specified number of bytes from the input buffer to the block.
+
+ The Write() function writes the specified number of bytes from
+ the provided buffer to the specified block and offset. If the
+ firmware volume is sticky write, the caller must ensure that
+ all the bits of the specified range to write are in the
+ EFI_FVB_ERASE_POLARITY state before calling the Write()
+ function, or else the result will be unpredictable. This
+ unpredictability arises because, for a sticky-write firmware
+ volume, a write may negate a bit in the EFI_FVB_ERASE_POLARITY
+ state but cannot flip it back again.  Before calling the
+ Write() function,  it is recommended for the caller to first call
+ the EraseBlocks() function to erase the specified block to
+ write. A block erase cycle will transition bits from the
+ (NOT)EFI_FVB_ERASE_POLARITY state back to the
+ EFI_FVB_ERASE_POLARITY state. Implementations should be
+ mindful that the firmware volume might be in the WriteDisabled
+ state. If it is in this state, the Write() function must
+ return the status code EFI_ACCESS_DENIED without modifying the
+ contents of the firmware volume. The Write() function must
+ also prevent spanning block boundaries. If a write is
+ requested that spans a block boundary, the write must store up
+ to the boundary but not beyond. The output parameter NumBytes
+ must be set to correctly indicate the number of bytes actually
+ written. The caller must be aware that a write may be
+ partially completed. All writes, partial or otherwise, must be
+ fully flushed to the hardware before the Write() service
+ returns.
+
+ @param This                 Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL instance.
+
+ @param Lba                  The starting logical block index to write to.
+
+ @param Offset               Offset into the block at which to begin writing.
+
+ @param NumBytes             The pointer to a UINTN.
+                             At entry, *NumBytes contains the total size of the buffer.
+                             At exit, *NumBytes contains the total number of bytes actually written.
+
+ @param Buffer               The pointer to a caller-allocated buffer that contains the source for the write.
+
+ @retval EFI_SUCCESS         The firmware volume was written successfully.
+
+ @retval EFI_BAD_BUFFER_SIZE The write was attempted across an LBA boundary.
+                             On output, NumBytes contains the total number of bytes
+                             actually written.
+
+ @retval EFI_ACCESS_DENIED   The firmware volume is in the WriteDisabled state.
+
+ @retval EFI_DEVICE_ERROR    The block device is malfunctioning and could not be written.
+
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbWrite (
+  IN CONST  EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  IN        EFI_LBA                              Lba,
+  IN        UINTN                                Offset,
+  IN OUT    UINTN                                *NumBytes,
+  IN        UINT8                                *Buffer
+  )
+{
+  UINTN              BlockSize;
+  SMMSTORE_INSTANCE  *Instance;
+
+  Instance = INSTANCE_FROM_FVB_THIS (This);
+
+  DEBUG ((DEBUG_BLKIO, "FvbWrite(Parameters: Lba=%ld, Offset=0x%x, *NumBytes=0x%x, Buffer @ 0x%08x)\n", Lba, Offset, *NumBytes, Buffer));
+
+  // Cache the block size to avoid de-referencing pointers all the time
+  BlockSize = Instance->BlockSize;
+
+  // The read must not span block boundaries.
+  // We need to check each variable individually because adding two large values together overflows.
+  if ((Offset               >= BlockSize) ||
+      (*NumBytes            >  BlockSize) ||
+      ((Offset + *NumBytes) >  BlockSize))
+  {
+    DEBUG ((DEBUG_ERROR, "FvbRead: ERROR - EFI_BAD_BUFFER_SIZE: (Offset=0x%x + NumBytes=0x%x) > BlockSize=0x%x\n", Offset, *NumBytes, BlockSize));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  // We must have some bytes to read
+  if (*NumBytes == 0) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  return SmmStoreLibWrite (Lba, Offset, NumBytes, Buffer);
+}
+
+/**
+ Erases and initialises a firmware volume block.
+
+ The EraseBlocks() function erases one or more blocks as denoted
+ by the variable argument list. The entire parameter list of
+ blocks must be verified before erasing any blocks. If a block is
+ requested that does not exist within the associated firmware
+ volume (it has a larger index than the last block of the
+ firmware volume), the EraseBlocks() function must return the
+ status code EFI_INVALID_PARAMETER without modifying the contents
+ of the firmware volume. Implementations should be mindful that
+ the firmware volume might be in the WriteDisabled state. If it
+ is in this state, the EraseBlocks() function must return the
+ status code EFI_ACCESS_DENIED without modifying the contents of
+ the firmware volume. All calls to EraseBlocks() must be fully
+ flushed to the hardware before the EraseBlocks() service
+ returns.
+
+ @param This                     Indicates the EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL
+ instance.
+
+ @param ...                      The variable argument list is a list of tuples.
+                                 Each tuple describes a range of LBAs to erase
+                                 and consists of the following:
+                                 - An EFI_LBA that indicates the starting LBA
+                                 - A UINTN that indicates the number of blocks to erase.
+
+                                 The list is terminated with an EFI_LBA_LIST_TERMINATOR.
+                                 For example, the following indicates that two ranges of blocks
+                                 (5-7 and 10-11) are to be erased:
+                                 EraseBlocks (This, 5, 3, 10, 2, EFI_LBA_LIST_TERMINATOR);
+
+ @retval EFI_SUCCESS             The erase request successfully completed.
+
+ @retval EFI_ACCESS_DENIED       The firmware volume is in the WriteDisabled state.
+
+ @retval EFI_DEVICE_ERROR        The block device is not functioning correctly and could not be written.
+                                 The firmware device may have been partially erased.
+
+ @retval EFI_INVALID_PARAMETER   One or more of the LBAs listed in the variable argument list do
+                                 not exist in the firmware volume.
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbEraseBlocks (
+  IN CONST EFI_FIRMWARE_VOLUME_BLOCK2_PROTOCOL  *This,
+  ...
+  )
+{
+  EFI_STATUS         Status;
+  VA_LIST            Args;
+  EFI_LBA            StartingLba; // Lba from which we start erasing
+  UINTN              NumOfLba;    // Number of Lba blocks to erase
+  SMMSTORE_INSTANCE  *Instance;
+
+  Instance = INSTANCE_FROM_FVB_THIS (This);
+
+  Status = EFI_SUCCESS;
+
+  // Before erasing, check the entire list of parameters to ensure all specified blocks are valid
+
+  VA_START (Args, This);
+  do {
+    // Get the Lba from which we start erasing
+    StartingLba = VA_ARG (Args, EFI_LBA);
+
+    // Have we reached the end of the list?
+    if (StartingLba == EFI_LBA_LIST_TERMINATOR) {
+      // Exit the while loop
+      break;
+    }
+
+    // How many Lba blocks are we requested to erase?
+    NumOfLba = VA_ARG (Args, UINTN);
+
+    // All blocks must be within range
+    DEBUG ((
+      DEBUG_BLKIO,
+      "FvbEraseBlocks: Check if: ( StartingLba=%ld + NumOfLba=%Lu - 1 ) > LastBlock=%ld.\n",
+      StartingLba,
+      (UINT64)NumOfLba,
+      Instance->LastBlock
+      ));
+    if ((NumOfLba == 0) || ((StartingLba + NumOfLba - 1) > Instance->LastBlock)) {
+      VA_END (Args);
+      DEBUG ((DEBUG_ERROR, "FvbEraseBlocks: ERROR - Lba range goes past the last Lba.\n"));
+      Status = EFI_INVALID_PARAMETER;
+      goto EXIT;
+    }
+  } while (TRUE);
+
+  VA_END (Args);
+
+  //
+  // To get here, all must be ok, so start erasing
+  //
+  VA_START (Args, This);
+  do {
+    // Get the Lba from which we start erasing
+    StartingLba = VA_ARG (Args, EFI_LBA);
+
+    // Have we reached the end of the list?
+    if (StartingLba == EFI_LBA_LIST_TERMINATOR) {
+      // Exit the while loop
+      break;
+    }
+
+    // How many Lba blocks are we requested to erase?
+    NumOfLba = VA_ARG (Args, UINTN);
+
+    // Go through each one and erase it
+    while (NumOfLba > 0) {
+      // Erase it
+      DEBUG ((DEBUG_BLKIO, "FvbEraseBlocks: Erasing Lba=%ld\n", StartingLba));
+      Status = SmmStoreLibEraseBlock (StartingLba);
+      if (EFI_ERROR (Status)) {
+        VA_END (Args);
+        Status = EFI_DEVICE_ERROR;
+        goto EXIT;
+      }
+
+      // Move to the next Lba
+      StartingLba++;
+      NumOfLba--;
+    }
+  } while (TRUE);
+
+  VA_END (Args);
+
+EXIT:
+  return Status;
+}
+
+/**
+  Initialized the Firmware Volume if necessary and installs the
+  gEdkiiNvVarStoreFormattedGuid protocol.
+
+  @param Instance                    Pointer to SmmStore instance
+
+ **/
+EFI_STATUS
+EFIAPI
+FvbInitialize (
+  IN SMMSTORE_INSTANCE  *Instance
+  )
+{
+  EFI_STATUS     Status;
+  UINT32         FvbNumLba;
+  EFI_BOOT_MODE  BootMode;
+
+  ASSERT ((Instance != NULL));
+
+  BootMode = GetBootModeHob ();
+  if (BootMode == BOOT_WITH_DEFAULT_SETTINGS) {
+    Status = EFI_INVALID_PARAMETER;
+  } else {
+    // Determine if there is a valid header at the beginning of the NorFlash
+    Status = ValidateFvHeader ();
+  }
+
+  // Install the Default FVB header if required
+  if (EFI_ERROR (Status)) {
+    // There is no valid header, so time to install one.
+    DEBUG ((DEBUG_INFO, "%a: The FVB Header is not valid.\n", __FUNCTION__));
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Installing a correct one for this volume.\n",
+      __FUNCTION__
+      ));
+
+    // Erase all the NorFlash that is reserved for variable storage
+    FvbNumLba = (PcdGet32 (PcdFlashNvStorageVariableSize) +
+                 PcdGet32 (PcdFlashNvStorageFtwWorkingSize) +
+                 PcdGet32 (PcdFlashNvStorageFtwSpareSize)) / Instance->BlockSize;
+
+    Status = FvbEraseBlocks (&Instance->FvbProtocol, (EFI_LBA)0, FvbNumLba, EFI_LBA_LIST_TERMINATOR);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    // Install all appropriate headers
+    Status = InitializeFvAndVariableStoreHeaders (Instance);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  } else {
+    DEBUG ((DEBUG_INFO, "%a: FVB header is valid\n", __FUNCTION__));
+  }
+
+  //
+  // The driver implementing the variable read service can now be dispatched;
+  // the varstore headers are in place.
+  //
+  Status = gBS->InstallProtocolInterface (
+                  &gImageHandle,
+                  &gEdkiiNvVarStoreFormattedGuid,
+                  EFI_NATIVE_INTERFACE,
+                  NULL
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
+++ b/Bootloader/coreboot/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
@@ -1,0 +1,63 @@
+## @file
+#  This is the component description file for SmmStore module.
+#
+#  Copyright (c) 2022, 9elements GmbH.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmStoreFvbRuntimeDxe
+  FILE_GUID                      = A0402FCA-6B25-4CEA-B7DD-C08F99714B29
+  MODULE_TYPE                    = DXE_RUNTIME_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = SmmStoreInitialize
+
+[Sources.common]
+  SmmStoreFvbRuntimeDxe.c
+  SmmStoreFvbRuntime.h
+  SmmStoreFvbRuntime.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  HobLib
+  SmmStoreLib
+  UefiLib
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+  UefiRuntimeLib
+  DxeServicesTableLib
+
+[Guids]
+  gEfiSystemNvDataFvGuid
+  gEfiVariableGuid                  ## PRODUCES ## PROTOCOL
+  gEfiAuthenticatedVariableGuid
+  gEfiEventVirtualAddressChangeGuid
+  gEdkiiNvVarStoreFormattedGuid     ## PRODUCES ## PROTOCOL
+
+[Protocols]
+  gEfiDevicePathProtocolGuid          ## BY_START
+  gEfiFirmwareVolumeBlockProtocolGuid ## BY_START
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64
+
+[Depex]
+  TRUE

--- a/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.c
@@ -1,0 +1,511 @@
+/** @file
+
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Guid/MemoryTypeInformation.h>
+#include "UefiPayloadEntry.h"
+
+STATIC UINT32  mTopOfLowerUsableDram = 0;
+
+EFI_MEMORY_TYPE_INFORMATION  mDefaultMemoryTypeInformation[] = {
+  { EfiACPIReclaimMemory,   FixedPcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory)   },
+  { EfiACPIMemoryNVS,       FixedPcdGet32 (PcdMemoryTypeEfiACPIMemoryNVS)       },
+  { EfiReservedMemoryType,  FixedPcdGet32 (PcdMemoryTypeEfiReservedMemoryType)  },
+  { EfiRuntimeServicesData, FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesData) },
+  { EfiRuntimeServicesCode, FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode) },
+  { EfiMaxMemoryType,       0                                                   }
+};
+
+/**
+   Function to reserve memory below 4GB for EDKII Modules.
+
+   This causes the DXE to dispatch everything under 4GB and allows Operating
+   System's that require EFI_LOADED_IMAGE to be under 4GB to start.
+   e.g. Xen hypervisor used in Qubes.
+**/
+VOID
+ForceModulesBelow4G (
+  VOID
+  )
+{
+  DEBUG ((DEBUG_INFO, "Building hob to restrict memory resorces to below 4G.\n"));
+
+  //
+  // Create Memory Type Information HOB
+  //
+  BuildGuidDataHob (
+    &gEfiMemoryTypeInformationGuid,
+    mDefaultMemoryTypeInformation,
+    sizeof (mDefaultMemoryTypeInformation)
+    );
+}
+
+/**
+   Callback function to build resource descriptor HOB
+
+   This function build a HOB based on the memory map entry info.
+   It creates only EFI_RESOURCE_MEMORY_MAPPED_IO and EFI_RESOURCE_MEMORY_RESERVED
+   resources.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 A pointer to ACPI_BOARD_INFO.
+
+  @retval EFI_SUCCESS            Successfully build a HOB.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter provided.
+**/
+EFI_STATUS
+MemInfoCallbackMmio (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  EFI_PHYSICAL_ADDRESS         Base;
+  EFI_RESOURCE_TYPE            Type;
+  UINT64                       Size;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  Attribue;
+  ACPI_BOARD_INFO              *AcpiBoardInfo;
+
+  AcpiBoardInfo = (ACPI_BOARD_INFO *)Params;
+  if (AcpiBoardInfo == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Skip types already handled in MemInfoCallback
+  //
+  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI)) {
+    return EFI_SUCCESS;
+  }
+
+  if (MemoryMapEntry->Base == AcpiBoardInfo->PcieBaseAddress) {
+    //
+    // MMCONF is always MMIO
+    //
+    Type = EFI_RESOURCE_MEMORY_MAPPED_IO;
+  } else if (MemoryMapEntry->Base < mTopOfLowerUsableDram) {
+    //
+    // It's in DRAM and thus must be reserved
+    //
+    Type = EFI_RESOURCE_MEMORY_RESERVED;
+  } else if ((MemoryMapEntry->Base < 0x100000000ULL) && (MemoryMapEntry->Base >= mTopOfLowerUsableDram)) {
+    //
+    // It's not in DRAM, must be MMIO
+    //
+    Type = EFI_RESOURCE_MEMORY_MAPPED_IO;
+  } else {
+    Type = EFI_RESOURCE_MEMORY_RESERVED;
+  }
+
+  Base = MemoryMapEntry->Base;
+  Size = MemoryMapEntry->Size;
+
+  Attribue = EFI_RESOURCE_ATTRIBUTE_PRESENT |
+             EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+             EFI_RESOURCE_ATTRIBUTE_TESTED |
+             EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE;
+
+  BuildResourceDescriptorHob (Type, Attribue, (EFI_PHYSICAL_ADDRESS)Base, Size);
+  DEBUG ((DEBUG_INFO, "buildhob: base = 0x%lx, size = 0x%lx, type = 0x%x\n", Base, Size, Type));
+
+  if ((MemoryMapEntry->Type == E820_UNUSABLE) ||
+      (MemoryMapEntry->Type == E820_DISABLED))
+  {
+    BuildMemoryAllocationHob (Base, Size, EfiUnusableMemory);
+  } else if (MemoryMapEntry->Type == E820_PMEM) {
+    BuildMemoryAllocationHob (Base, Size, EfiPersistentMemory);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Callback function to find TOLUD (Top of Lower Usable DRAM)
+
+   Estimate where TOLUD (Top of Lower Usable DRAM) resides. The exact position
+   would require platform specific code.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 Not used for now.
+
+  @retval EFI_SUCCESS            Successfully updated mTopOfLowerUsableDram.
+**/
+EFI_STATUS
+FindToludCallback (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  //
+  // This code assumes that the memory map on this x86 machine below 4GiB is continous
+  // until TOLUD. In addition it assumes that the bootloader provided memory tables have
+  // no "holes" and thus the first memory range not covered by e820 marks the end of
+  // usable DRAM. In addition it's assumed that every reserved memory region touching
+  // usable RAM is also covering DRAM, everything else that is marked reserved thus must be
+  // MMIO not detectable by bootloader/OS
+  //
+
+  //
+  // Skip memory types not RAM or reserved
+  //
+  if ((MemoryMapEntry->Type == E820_UNUSABLE) || (MemoryMapEntry->Type == E820_DISABLED) ||
+      (MemoryMapEntry->Type == E820_PMEM))
+  {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Skip resources above 4GiB
+  //
+  if ((MemoryMapEntry->Base + MemoryMapEntry->Size) > 0x100000000ULL) {
+    return EFI_SUCCESS;
+  }
+
+  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI) ||
+      (MemoryMapEntry->Type == E820_NVS))
+  {
+    //
+    // It's usable DRAM. Update TOLUD.
+    //
+    if (mTopOfLowerUsableDram < (MemoryMapEntry->Base + MemoryMapEntry->Size)) {
+      mTopOfLowerUsableDram = (UINT32)(MemoryMapEntry->Base + MemoryMapEntry->Size);
+    }
+  } else {
+    //
+    // It might be 'reserved DRAM' or 'MMIO'.
+    //
+    // If it touches usable DRAM at Base assume it's DRAM as well,
+    // as it could be bootloader installed tables, TSEG, GTT, ...
+    //
+    if (mTopOfLowerUsableDram == MemoryMapEntry->Base) {
+      mTopOfLowerUsableDram = (UINT32)(MemoryMapEntry->Base + MemoryMapEntry->Size);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Callback function to build resource descriptor HOB
+
+   This function build a HOB based on the memory map entry info.
+   Only add EFI_RESOURCE_SYSTEM_MEMORY.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 Not used for now.
+
+  @retval RETURN_SUCCESS        Successfully build a HOB.
+**/
+EFI_STATUS
+MemInfoCallback (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  EFI_PHYSICAL_ADDRESS         Base;
+  EFI_RESOURCE_TYPE            Type;
+  UINT64                       Size;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  Attribue;
+
+  //
+  // Skip everything not known to be usable DRAM.
+  // It will be added later.
+  //
+  if ((MemoryMapEntry->Type != E820_RAM) && (MemoryMapEntry->Type != E820_ACPI) &&
+      (MemoryMapEntry->Type != E820_NVS))
+  {
+    return RETURN_SUCCESS;
+  }
+
+  Type = EFI_RESOURCE_SYSTEM_MEMORY;
+  Base = MemoryMapEntry->Base;
+  Size = MemoryMapEntry->Size;
+
+  Attribue = EFI_RESOURCE_ATTRIBUTE_PRESENT |
+             EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+             EFI_RESOURCE_ATTRIBUTE_TESTED |
+             EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE;
+
+  BuildResourceDescriptorHob (Type, Attribue, (EFI_PHYSICAL_ADDRESS)Base, Size);
+  DEBUG ((DEBUG_INFO, "buildhob: base = 0x%lx, size = 0x%lx, type = 0x%x\n", Base, Size, Type));
+
+  if (MemoryMapEntry->Type == E820_ACPI) {
+    BuildMemoryAllocationHob (Base, Size, EfiACPIReclaimMemory);
+  } else if (MemoryMapEntry->Type == E820_NVS) {
+    BuildMemoryAllocationHob (Base, Size, EfiACPIMemoryNVS);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  It will build HOBs based on information from bootloaders.
+
+  @retval EFI_SUCCESS        If it completed successfully.
+  @retval Others             If it failed to build required HOBs.
+**/
+EFI_STATUS
+BuildHobFromBl (
+  VOID
+  )
+{
+  EFI_STATUS                        Status;
+  ACPI_BOARD_INFO                   *AcpiBoardInfo;
+  SMMSTORE_INFO                     SmmStoreInfo;
+  SMMSTORE_INFO                     *NewSmmStoreInfo;
+  EFI_PEI_GRAPHICS_INFO_HOB         GfxInfo;
+  EFI_PEI_GRAPHICS_INFO_HOB         *NewGfxInfo;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  GfxDeviceInfo;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *NewGfxDeviceInfo;
+  UNIVERSAL_PAYLOAD_SMBIOS_TABLE    *SmBiosTableHob;
+  UNIVERSAL_PAYLOAD_ACPI_TABLE      *AcpiTableHob;
+
+  //
+  // First find TOLUD
+  //
+  DEBUG ((DEBUG_INFO, "Guessing Top of Lower Usable DRAM:\n"));
+  Status = ParseMemoryInfo (FindToludCallback, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "Assuming TOLUD = 0x%x\n", mTopOfLowerUsableDram));
+
+  //
+  // Parse memory info and build memory HOBs for Usable RAM
+  //
+  DEBUG ((DEBUG_INFO, "Building ResourceDescriptorHobs for usable memory:\n"));
+  Status = ParseMemoryInfo (MemInfoCallback, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Create guid hob for frame buffer information
+  //
+  Status = ParseGfxInfo (&GfxInfo);
+  if (!EFI_ERROR (Status)) {
+    NewGfxInfo = BuildGuidHob (&gEfiGraphicsInfoHobGuid, sizeof (GfxInfo));
+    ASSERT (NewGfxInfo != NULL);
+    CopyMem (NewGfxInfo, &GfxInfo, sizeof (GfxInfo));
+    DEBUG ((DEBUG_INFO, "Created graphics info hob\n"));
+  }
+
+  Status = ParseGfxDeviceInfo (&GfxDeviceInfo);
+  if (!EFI_ERROR (Status)) {
+    NewGfxDeviceInfo = BuildGuidHob (&gEfiGraphicsDeviceInfoHobGuid, sizeof (GfxDeviceInfo));
+    ASSERT (NewGfxDeviceInfo != NULL);
+    CopyMem (NewGfxDeviceInfo, &GfxDeviceInfo, sizeof (GfxDeviceInfo));
+    DEBUG ((DEBUG_INFO, "Created graphics device info hob\n"));
+  }
+
+  //
+  // Create guid hob for SmmStore
+  //
+  Status = ParseSmmStoreInfo (&SmmStoreInfo);
+  if (!EFI_ERROR (Status)) {
+    NewSmmStoreInfo = BuildGuidHob (&gEfiSmmStoreInfoHobGuid, sizeof (SmmStoreInfo));
+    ASSERT (NewSmmStoreInfo != NULL);
+    CopyMem (NewSmmStoreInfo, &SmmStoreInfo, sizeof (SmmStoreInfo));
+    DEBUG ((DEBUG_INFO, "Created SmmStore info hob\n"));
+  }
+
+  //
+  // Creat SmBios table Hob
+  //
+  SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
+  ASSERT (SmBiosTableHob != NULL);
+  SmBiosTableHob->Header.Revision = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
+  SmBiosTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
+  DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
+  Status = ParseSmbiosTable (SmBiosTableHob);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosTableHob->SmBiosEntryPoint));
+  }
+
+  //
+  // Creat ACPI table Hob
+  //
+  AcpiTableHob = BuildGuidHob (&gUniversalPayloadAcpiTableGuid, sizeof (UNIVERSAL_PAYLOAD_ACPI_TABLE));
+  ASSERT (AcpiTableHob != NULL);
+  AcpiTableHob->Header.Revision = UNIVERSAL_PAYLOAD_ACPI_TABLE_REVISION;
+  AcpiTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_ACPI_TABLE);
+  DEBUG ((DEBUG_INFO, "Create ACPI table gUniversalPayloadAcpiTableGuid guid hob\n"));
+  Status = ParseAcpiTableInfo (AcpiTableHob);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "Detected ACPI Table at 0x%lx\n", AcpiTableHob->Rsdp));
+  }
+
+  //
+  // Create guid hob for acpi board information
+  //
+  AcpiBoardInfo = BuildHobFromAcpi (AcpiTableHob->Rsdp);
+  ASSERT (AcpiBoardInfo != NULL);
+
+  //
+  // Parse memory info and build memory HOBs for reserved DRAM and MMIO
+  //
+  DEBUG ((DEBUG_INFO, "Building ResourceDescriptorHobs for reserved memory:\n"));
+  Status = ParseMemoryInfo (MemInfoCallbackMmio, AcpiBoardInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Parse the misc info provided by bootloader
+  //
+  Status = ParseMiscInfo ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "Error when parsing misc info, Status = %r\n", Status));
+  }
+
+  //
+  // Parse platform specific information.
+  //
+  Status = ParsePlatformInfo ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Error when parsing platform info, Status = %r\n", Status));
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function will build some generic HOBs that doesn't depend on information from bootloaders.
+
+**/
+VOID
+BuildGenericHob (
+  VOID
+  )
+{
+  UINT32                       RegEax;
+  UINT8                        PhysicalAddressBits;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute;
+
+  // The UEFI payload FV
+  BuildMemoryAllocationHob (PcdGet32 (PcdPayloadFdMemBase), PcdGet32 (PcdPayloadFdMemSize), EfiBootServicesData);
+
+  //
+  // Build CPU memory space and IO space hob
+  //
+  AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
+  if (RegEax >= 0x80000008) {
+    AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
+    PhysicalAddressBits = (UINT8)RegEax;
+  } else {
+    PhysicalAddressBits = 36;
+  }
+
+  BuildCpuHob (PhysicalAddressBits, 16);
+
+  //
+  // Report Local APIC range, cause sbl HOB to be NULL, comment now
+  //
+  ResourceAttribute = (
+                       EFI_RESOURCE_ATTRIBUTE_PRESENT |
+                       EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+                       EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+                       EFI_RESOURCE_ATTRIBUTE_TESTED
+                       );
+  BuildResourceDescriptorHob (EFI_RESOURCE_MEMORY_MAPPED_IO, ResourceAttribute, 0xFEC80000, SIZE_512KB);
+  BuildMemoryAllocationHob (0xFEC80000, SIZE_512KB, EfiMemoryMappedIO);
+}
+
+/**
+  Entry point to the C language phase of UEFI payload.
+
+  @param[in]   BootloaderParameter    The starting address of bootloader parameter block.
+
+  @retval      It will not return if SUCCESS, and return error when passing bootloader parameter.
+**/
+EFI_STATUS
+EFIAPI
+_ModuleEntryPoint (
+  IN UINTN  BootloaderParameter
+  )
+{
+  EFI_STATUS                          Status;
+  PHYSICAL_ADDRESS                    DxeCoreEntryPoint;
+  UINTN                               MemBase;
+  UINTN                               HobMemBase;
+  UINTN                               HobMemTop;
+  EFI_PEI_HOB_POINTERS                Hob;
+  SERIAL_PORT_INFO                    SerialPortInfo;
+  UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO  *UniversalSerialPort;
+
+  Status = PcdSet64S (PcdBootloaderParameter, BootloaderParameter);
+  ASSERT_EFI_ERROR (Status);
+
+  // Initialize floating point operating environment to be compliant with UEFI spec.
+  InitializeFloatingPointUnits ();
+
+  // HOB region is used for HOB and memory allocation for this module
+  MemBase    = PcdGet32 (PcdPayloadFdMemBase);
+  HobMemBase = ALIGN_VALUE (MemBase + PcdGet32 (PcdPayloadFdMemSize), SIZE_1MB);
+  HobMemTop  = HobMemBase + FixedPcdGet32 (PcdSystemMemoryUefiRegionSize);
+
+  HobConstructor ((VOID *)MemBase, (VOID *)HobMemTop, (VOID *)HobMemBase, (VOID *)HobMemTop);
+
+  //
+  // Build serial port info
+  //
+  Status = ParseSerialInfo (&SerialPortInfo);
+  if (!EFI_ERROR (Status)) {
+    UniversalSerialPort = BuildGuidHob (&gUniversalPayloadSerialPortInfoGuid, sizeof (UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO));
+    ASSERT (UniversalSerialPort != NULL);
+    UniversalSerialPort->Header.Revision = UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO_REVISION;
+    UniversalSerialPort->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO);
+    UniversalSerialPort->UseMmio         = (SerialPortInfo.Type == 1) ? FALSE : TRUE;
+    UniversalSerialPort->RegisterBase    = SerialPortInfo.BaseAddr;
+    UniversalSerialPort->BaudRate        = SerialPortInfo.Baud;
+    UniversalSerialPort->RegisterStride  = (UINT8)SerialPortInfo.RegWidth;
+  }
+
+  // The library constructors might depend on serial port, so call it after serial port hob
+  ProcessLibraryConstructorList ();
+  DEBUG ((DEBUG_INFO, "sizeof(UINTN) = 0x%x\n", sizeof (UINTN)));
+
+  // Build HOB based on information from Bootloader
+  Status = BuildHobFromBl ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "BuildHobFromBl Status = %r\n", Status));
+    return Status;
+  }
+
+  // Build other HOBs required by DXE
+  BuildGenericHob ();
+
+  // Create a HOB to make resources for EDKII modules below 4G
+  if (!FixedPcdGetBool (PcdDispatchModuleAbove4GMemory)) {
+    ForceModulesBelow4G ();
+  }
+
+  // Load the DXE Core
+  Status = LoadDxeCore (&DxeCoreEntryPoint);
+  ASSERT_EFI_ERROR (Status);
+
+  DEBUG ((DEBUG_INFO, "DxeCoreEntryPoint = 0x%lx\n", DxeCoreEntryPoint));
+
+  //
+  // Mask off all legacy 8259 interrupt sources
+  //
+  IoWrite8 (LEGACY_8259_MASK_REGISTER_MASTER, 0xFF);
+  IoWrite8 (LEGACY_8259_MASK_REGISTER_SLAVE, 0xFF);
+
+  Hob.HandoffInformationTable = (EFI_HOB_HANDOFF_INFO_TABLE *)GetFirstHob (EFI_HOB_TYPE_HANDOFF);
+  HandOffToDxeCore (DxeCoreEntryPoint, Hob);
+
+  // Should not get here
+  CpuDeadLoop ();
+  return EFI_SUCCESS;
+}

--- a/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.h
@@ -1,0 +1,222 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __UEFI_PAYLOAD_ENTRY_H__
+#define __UEFI_PAYLOAD_ENTRY_H__
+
+#include <PiPei.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PeCoffLib.h>
+#include <Library/HobLib.h>
+#include <Library/PcdLib.h>
+#include <Guid/MemoryAllocationHob.h>
+#include <Library/IoLib.h>
+#include <Library/PeCoffLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/SmmStoreParseLib.h>
+#include <Library/PlatformSupportLib.h>
+#include <Library/CpuLib.h>
+#include <Library/UefiCpuLib.h>
+#include <IndustryStandard/Acpi.h>
+#include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
+#include <Guid/SerialPortInfoGuid.h>
+#include <Guid/MemoryMapInfoGuid.h>
+#include <Guid/AcpiBoardInfoGuid.h>
+#include <Guid/GraphicsInfoHob.h>
+#include <UniversalPayload/SmbiosTable.h>
+#include <UniversalPayload/AcpiTable.h>
+#include <UniversalPayload/UniversalPayload.h>
+#include <UniversalPayload/ExtraData.h>
+#include <UniversalPayload/SerialPortInfo.h>
+#include <Guid/PcdDataBaseSignatureGuid.h>
+#include <Guid/SmmStoreInfoGuid.h>
+
+#define LEGACY_8259_MASK_REGISTER_MASTER  0x21
+#define LEGACY_8259_MASK_REGISTER_SLAVE   0xA1
+#define GET_OCCUPIED_SIZE(ActualSize, Alignment) \
+  ((ActualSize) + (((Alignment) - ((ActualSize) & ((Alignment) - 1))) & ((Alignment) - 1)))
+
+#define E820_RAM        1
+#define E820_RESERVED   2
+#define E820_ACPI       3
+#define E820_NVS        4
+#define E820_UNUSABLE   5
+#define E820_DISABLED   6
+#define E820_PMEM       7
+#define E820_UNDEFINED  8
+
+/**
+  Auto-generated function that calls the library constructors for all of the module's
+  dependent libraries.
+**/
+VOID
+EFIAPI
+ProcessLibraryConstructorList (
+  VOID
+  );
+
+/**
+  Add a new HOB to the HOB List.
+
+  @param HobType            Type of the new HOB.
+  @param HobLength          Length of the new HOB to allocate.
+
+  @return  NULL if there is no space to create a hob.
+  @return  The address point to the new created hob.
+
+**/
+VOID *
+EFIAPI
+CreateHob (
+  IN  UINT16  HobType,
+  IN  UINT16  HobLength
+  );
+
+/**
+  Update the Stack Hob if the stack has been moved
+
+  @param  BaseAddress   The 64 bit physical address of the Stack.
+  @param  Length        The length of the stack in bytes.
+
+**/
+VOID
+EFIAPI
+UpdateStackHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length
+  );
+
+/**
+  Build a Handoff Information Table HOB
+
+  This function initialize a HOB region from EfiMemoryBegin to
+  EfiMemoryTop. And EfiFreeMemoryBottom and EfiFreeMemoryTop should
+  be inside the HOB region.
+
+  @param[in] EfiMemoryBottom       Total memory start address
+  @param[in] EfiMemoryTop          Total memory end address.
+  @param[in] EfiFreeMemoryBottom   Free memory start address
+  @param[in] EfiFreeMemoryTop      Free memory end address.
+
+  @return   The pointer to the handoff HOB table.
+
+**/
+EFI_HOB_HANDOFF_INFO_TABLE *
+EFIAPI
+HobConstructor (
+  IN VOID  *EfiMemoryBottom,
+  IN VOID  *EfiMemoryTop,
+  IN VOID  *EfiFreeMemoryBottom,
+  IN VOID  *EfiFreeMemoryTop
+  );
+
+/**
+  Find DXE core from FV and build DXE core HOBs.
+
+  @param[out]  DxeCoreEntryPoint     DXE core entry point
+
+  @retval EFI_SUCCESS        If it completed successfully.
+  @retval EFI_NOT_FOUND      If it failed to load DXE FV.
+**/
+EFI_STATUS
+LoadDxeCore (
+  OUT PHYSICAL_ADDRESS  *DxeCoreEntryPoint
+  );
+
+/**
+  Find DXE core from FV and build DXE core HOBs.
+
+  @param[in]   DxeFv                 The FV where to find the DXE core.
+  @param[out]  DxeCoreEntryPoint     DXE core entry point
+
+  @retval EFI_SUCCESS        If it completed successfully.
+  @retval EFI_NOT_FOUND      If it failed to load DXE FV.
+**/
+EFI_STATUS
+UniversalLoadDxeCore (
+  IN  EFI_FIRMWARE_VOLUME_HEADER  *DxeFv,
+  OUT PHYSICAL_ADDRESS            *DxeCoreEntryPoint
+  );
+
+/**
+   Transfers control to DxeCore.
+
+   This function performs a CPU architecture specific operations to execute
+   the entry point of DxeCore with the parameters of HobList.
+
+   @param DxeCoreEntryPoint         The entry point of DxeCore.
+   @param HobList                   The start of HobList passed to DxeCore.
+**/
+VOID
+HandOffToDxeCore (
+  IN EFI_PHYSICAL_ADDRESS  DxeCoreEntryPoint,
+  IN EFI_PEI_HOB_POINTERS  HobList
+  );
+
+EFI_STATUS
+FixUpPcdDatabase (
+  IN  EFI_FIRMWARE_VOLUME_HEADER  *DxeFv
+  );
+
+/**
+  This function searchs a given section type within a valid FFS file.
+
+  @param  FileHeader            A pointer to the file header that contains the set of sections to
+                                be searched.
+  @param  SearchType            The value of the section type to search.
+  @param  SectionData           A pointer to the discovered section, if successful.
+
+  @retval EFI_SUCCESS           The section was found.
+  @retval EFI_NOT_FOUND         The section was not found.
+
+**/
+EFI_STATUS
+FileFindSection (
+  IN EFI_FFS_FILE_HEADER  *FileHeader,
+  IN EFI_SECTION_TYPE     SectionType,
+  OUT VOID                **SectionData
+  );
+
+/**
+  This function searchs a given file type with a given Guid within a valid FV.
+  If input Guid is NULL, will locate the first section having the given file type
+
+  @param FvHeader        A pointer to firmware volume header that contains the set of files
+                         to be searched.
+  @param FileType        File type to be searched.
+  @param Guid            Will ignore if it is NULL.
+  @param FileHeader      A pointer to the discovered file, if successful.
+
+  @retval EFI_SUCCESS    Successfully found FileType
+  @retval EFI_NOT_FOUND  File type can't be found.
+**/
+EFI_STATUS
+FvFindFileByTypeGuid (
+  IN  EFI_FIRMWARE_VOLUME_HEADER  *FvHeader,
+  IN  EFI_FV_FILETYPE             FileType,
+  IN  EFI_GUID                    *Guid           OPTIONAL,
+  OUT EFI_FFS_FILE_HEADER         **FileHeader
+  );
+
+/**
+  Build ACPI board info HOB using infomation from ACPI table
+
+  @param  AcpiTableBase      ACPI table start address in memory
+
+  @retval  A pointer to ACPI board HOB ACPI_BOARD_INFO. Null if build HOB failure.
+**/
+ACPI_BOARD_INFO *
+BuildHobFromAcpi (
+  IN   UINT64  AcpiTableBase
+  );
+
+#endif

--- a/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.inf
+++ b/Bootloader/coreboot/UefiPayloadEntry/UefiPayloadEntry.inf
@@ -1,0 +1,102 @@
+## @file
+#  This is the first module for UEFI payload.
+#
+#  Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PayloadEntry
+  FILE_GUID                      = 2119BBD7-9432-4f47-B5E2-5C4EA31B6BDC
+  MODULE_TYPE                    = SEC
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  UefiPayloadEntry.c
+  LoadDxeCore.c
+  MemoryAllocation.c
+  AcpiTable.c
+
+[Sources.Ia32]
+  X64/VirtualMemory.h
+  X64/VirtualMemory.c
+  Ia32/DxeLoadFunc.c
+  Ia32/IdtVectorAsm.nasm
+
+[Sources.X64]
+  X64/VirtualMemory.h
+  X64/VirtualMemory.c
+  X64/DxeLoadFunc.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  BaseLib
+  SerialPortLib
+  IoLib
+  BlParseLib
+  HobLib
+  PeCoffLib
+  PlatformSupportLib
+  CpuLib
+  UefiCpuLib
+
+[Guids]
+  gEfiMemoryTypeInformationGuid
+  gEfiFirmwareFileSystem2Guid
+  gEfiGraphicsInfoHobGuid
+  gEfiGraphicsDeviceInfoHobGuid
+  gUefiAcpiBoardInfoGuid
+  gUniversalPayloadSmbiosTableGuid
+  gUniversalPayloadAcpiTableGuid
+  gUniversalPayloadSerialPortInfoGuid
+  gEfiSmmStoreInfoHobGuid
+
+[FeaturePcd.IA32]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode      ## CONSUMES
+
+[FeaturePcd.X64]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplBuildPageTables       ## CONSUMES
+
+
+[Pcd.IA32,Pcd.X64]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdUse1GPageTable                      ## SOMETIMES_CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                       ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbBase                            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbSize                            ## CONSUMES
+
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter
+  gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiACPIMemoryNVS
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiACPIReclaimMemory
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
+  gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
+
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSetNxForStack               ## SOMETIMES_CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy ## SOMETIMES_CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy       ## SOMETIMES_CONSUMES
+
+  gUefiPayloadPkgTokenSpaceGuid.PcdDispatchModuleAbove4GMemory
+

--- a/Bootloader/coreboot/corebootPkg.dec
+++ b/Bootloader/coreboot/corebootPkg.dec
@@ -1,0 +1,19 @@
+## @file
+# coreboot Package
+#
+# Provides drivers and definitions to create payload platform FV.
+#
+# Copyright (c) 2022, StarLabs. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION              = 0x00010005
+  PACKAGE_NAME                   = PayloadPlatformPkg
+  PACKAGE_GUID                   = 554f7c44-2210-43c6-8176-1481710b6478
+  PACKAGE_VERSION                = 0.1
+
+[Guids]
+  gEfiSmmStoreInfoHobGuid  = { 0xf585ca19, 0x881b, 0x44fb, { 0x3f, 0x3d, 0x81, 0x89, 0x7c, 0x57, 0xbb, 0x01 } }
+

--- a/Bootloader/coreboot/corebootPkg.dsc
+++ b/Bootloader/coreboot/corebootPkg.dsc
@@ -1,0 +1,50 @@
+## @file
+# coreboot Package
+#
+# Provides coreboot specific drivers and definitions to create a platform FV
+# to work with UefiPayloadPkg and Universal Payload.
+#
+# Copyright (c) 2022, Star Labs. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  PLATFORM_NAME                       = corebootPkg
+  PLATFORM_GUID                       = 8b2d70f1-b0be-4916-b5f8-80d0bb5c09d3
+  PLATFORM_VERSION                    = 0.1
+  DSC_SPECIFICATION                   = 0x00010005
+  SUPPORTED_ARCHITECTURES             = IA32|X64
+  BUILD_TARGETS                       = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER                    = DEFAULT
+  OUTPUT_DIRECTORY                    = Build/corebootX64
+  FLASH_DEFINITION                    = corebootPkg/corebootPkg.fdf
+  PCD_DYNAMIC_AS_DYNAMICEX            = TRUE
+
+[LibraryClasses]
+  SmmStoreLib|UefiPayloadPkg/Library/SmmStoreLib/SmmStoreLib.inf
+  TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+
+[PcdsFixedAtBuild]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|FALSE
+
+[PcdsDynamicExDefault]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0
+
+[Components.X64]
+  UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
+  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
+    <LibraryClasses>
+      NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
+      NULL|EmbeddedPkg/Library/NvVarStoreFormattedLib/NvVarStoreFormattedLib.inf
+  }
+

--- a/Bootloader/coreboot/corebootPkg.fdf
+++ b/Bootloader/coreboot/corebootPkg.fdf
@@ -1,0 +1,60 @@
+## @file
+# Payload platform Package
+#
+# Provides coreboot specific drivers and definitions to create a platform FV
+# to work with UefiPayloadPlg and universal Payload.
+#
+# Copyright (c) 2022, StarLabs. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+DEFINE FD_BASE       = 0x00800000
+DEFINE FD_BLOCK_SIZE = 0x00001000
+
+!if $(TARGET) == "NOOPT"
+DEFINE FD_SIZE     = 0x00090000
+DEFINE NUM_BLOCKS  = 0x90
+!else
+
+DEFINE FD_SIZE     = 0x00050000
+DEFINE NUM_BLOCKS  = 0x50
+!endif
+
+################################################################################
+[FD.UefiPayload]
+BaseAddress   = $(FD_BASE) | gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
+Size          = $(FD_SIZE) | gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
+ErasePolarity = 1
+BlockSize     = $(FD_BLOCK_SIZE)
+NumBlocks     = $(NUM_BLOCKS)
+
+0x00000000|$(FD_SIZE)
+FV = PLATFORMFV
+
+################################################################################
+[FV.PLATFORMFV]
+FvNameGuid         = 927bf473-013c-413d-bd06-340091aa7c5f
+BlockSize          = $(FD_BLOCK_SIZE)
+FvForceRebase      = FALSE
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+INF UefiPayloadPkg/SmmStoreFvb/SmmStoreFvbRuntimeDxe.inf
+INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf


### PR DESCRIPTION
This adds support for FVB in order to support a platform independent
and non-volatile variable store on UefiPayloadPkg. The variable store
makes use the SmmStoreLib to provide an unauthenticed variable store.

Since commit bc744f5893fc4d53275ed26dd8d968011c6a09c1 coreboot supports
the SMMSTORE v2 feature. It implements a SMI handler that is able to
write, read and erase pages in the boot media (SPI flash).
The communication is done using a fixed communication buffer that is
allocated in CBMEM. The existence of this optional feature is advertised
by a coreboot table.
When the SMMSTORE feature is not available the variable emulation is used
by setting PcdEmuVariableNvModeEnable to TRUE.

The DXE component provides runtime services and takes care of virtual to
physical mapping the communication buffers between SMM and OS.

The contents of the variable store can be accessed and modified by any
priviledged application. As authentication is done by runtime services
only the store shouldn't be used to store authenticated variables.

Tested on Linux and Windows 10 on real hardware.
Currently this cannot be tested on coreboot and qemu as it doesn't support
the SMMSTORE on qemu.

Cc: Guo Dong <guo.dong@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Patrick Rudolph <patrick.rudolph@9elements.com>
Signed-off-by: Sean Rhodes <sean@starlabs.systems>